### PR TITLE
WIP: Github Actions for publishing Operator images (#2089)

### DIFF
--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -1,0 +1,47 @@
+name: Build Release Images
+
+on:
+  push:
+    #    branches:
+    #  - master
+jobs:
+  build-images:
+    if: github.repository_owner == 'armadaproject'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0		# see https://github.com/marketplace/actions/goreleaser-action#usage
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --clean
+
+      - name: Build Operator Docker image
+        run: cd ./dist/goreleaserdocker* && docker build -t armada-operator -f Dockerfile .
+
+      - name: Save docker images to artifact
+        run: |
+          mkdir -p docker-images
+          docker save armada-operator | gzip > docker-images/armada-operator.tar.gz
+
+          tar -czf docker-images.tar.gz docker-images/*
+
+      - name: Upload docker image tarball to artifacts
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: docker-images
+          path: docker-images.tar.gz
+          if-no-files-found: error
+# invoke-image-push:
+#   name: Push Docker Image artifacts to Docker Hub
+#   needs: test-and-build-images
+#   uses: ./.github/workflows/upload-docker-images.yml
+#   secrets: inherit

--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -37,8 +37,8 @@ jobs:
           name: docker-images
           path: docker-images.tar.gz
           if-no-files-found: error
- invoke-image-push:
-   name: Push Docker Image artifacts to Docker Hub
-   needs: test-and-build-images
-   uses: ./.github/workflows/upload-docker-images.yml
-   secrets: inherit
+  invoke-image-push:
+    name: Push Docker Image artifacts to Docker Hub
+    needs: test-and-build-images
+    uses: ./.github/workflows/upload-docker-images.yml
+    secrets: inherit

--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -2,8 +2,8 @@ name: Build Release Images
 
 on:
   push:
-    #    branches:
-    #  - master
+    branches:
+      - master
 jobs:
   build-images:
     if: github.repository_owner == 'armadaproject'
@@ -37,8 +37,8 @@ jobs:
           name: docker-images
           path: docker-images.tar.gz
           if-no-files-found: error
-# invoke-image-push:
-#   name: Push Docker Image artifacts to Docker Hub
-#   needs: test-and-build-images
-#   uses: ./.github/workflows/upload-docker-images.yml
-#   secrets: inherit
+ invoke-image-push:
+   name: Push Docker Image artifacts to Docker Hub
+   needs: test-and-build-images
+   uses: ./.github/workflows/upload-docker-images.yml
+   secrets: inherit

--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -17,15 +17,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser to build Docker image
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest
           args: release --snapshot --clean
-
-      - name: Build Operator Docker image
-        run: pwd; ls; cd ./dist/goreleaserdocker* && docker build -t armada-operator -f Dockerfile .
 
       - name: Save docker images to artifact
         run: |

--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -25,7 +25,7 @@ jobs:
           args: release --snapshot --clean
 
       - name: Build Operator Docker image
-        run: cd ./dist/goreleaserdocker* && docker build -t armada-operator -f Dockerfile .
+        run: pwd; ls; cd ./dist/goreleaserdocker* && docker build -t armada-operator -f Dockerfile .
 
       - name: Save docker images to artifact
         run: |

--- a/.github/workflows/upload-docker-images.yml
+++ b/.github/workflows/upload-docker-images.yml
@@ -1,0 +1,35 @@
+name: Release Armada
+
+on:
+  workflow_call: {}
+
+jobs:
+  upload-docker-images:
+    runs-on: ubuntu-latest
+    environment: armada-dockerhub
+    steps:
+      - name: Download saved docker-images artifact
+        uses: actions/download-artifact@v3.0.1
+        with:
+          name: docker-images
+      - name: Unzip docker-images artifacts
+        run: |
+          tar xf docker-images.tar.gz
+          rm docker-images.tar.gz
+      - name: Upload images to docker
+        run: |
+          TAG_SUFFIX=$(echo "${{ github.sha }}" | sed 's|/|-|g')
+
+          if [ "${{github.ref_name}}" = "master" ]; then
+            TAG="$TAG_SUFFIX"
+          else
+            TAG="${{ github.ref_name }}-$TAG_SUFFIX"
+          fi
+
+          echo ${{ secrets.DOCKERHUB_PASS }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+
+          remote="gresearch/armada-operator:${TAG}"
+          docker load -i docker-images/armada-operator.tar.gz
+          docker tag armada-operator:latest $remote
+          echo "Pushing armada-operatorto Docker Hub $remote"
+          docker push $remote

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,8 @@ builds:
     goarch:
       - amd64
 
-sboms:
-  - artifacts: archive
+#sboms:
+#  - artifacts: archive
 
 env:
   - DOCKER_REPO={{ if index .Env "DOCKER_REPO"  }}{{ .Env.DOCKER_REPO }}/{{ else }}{{ end }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Contributor Code of Conduct
+
+Guiding us in our day-to-day interactions and decision-making are the values of trust, respect, collaboration and transparency. Our community welcomes participants from around the world with different experiences, personalities, unique perspectives, and great ideas to share.
+
+We expect this code of conduct to be honored by everyone who participates in the Armada community formally or informally.
+
+This code is not exhaustive or complete, and is a living document. It serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter, so that it can enrich all of us and the technical communities in which we participate.
+
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation. 
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Attempting collaboration before conflict.
+* Focusing on what is best for the community.
+* Appreciating time and effort contributed by members.
+* Showing empathy towards other community members.
+
+
+Examples of unacceptable behavior by participants include:
+
+* Violence, threats of violence, or inciting others to commit self-harm.
+* The use of sexualized language or imagery and unwelcome sexual attention or advances.
+* Trolling, intentionally spreading misinformation, insulting/derogatory comments, and personal or political attacks, including [challenging someone’s self-identity](https://lgbtq.technology/culture.html#discussion-of-labels).
+* Public or private [harassment](https://lgbtq.technology/coc.html#harassment), aggression, deliberate intimidation, or threats.
+* [Feigning or exaggerating surprise](https://www.recurse.com/manual#no-feigned-surprise) when someone admits to not knowing something, or excusing a disrespectful communication as “ironic” or “joking”.
+* Publishing others' private information, such as a physical or electronic address, without explicit permission. This includes any sort of “outing” of any aspect of someone’s identity without their consent.
+* Abuse of the reporting process to intentionally harass or exclude others.
+* Advocating for, or encouraging, any of the above behavior.
+* Other conduct which could reasonably be considered inappropriate in a professional or community setting.
+
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+
+## Scope
+
+This Code of Conduct applies both within spaces involving this project and in other spaces involving community members. This includes the repository, its Pull Requests and Issue tracker, its Gitter community, private email communications in the context of the project, and any events where members of the project are participating, as well as adjacent communities and venues affecting the project’s members.
+
+Depending on the violation, the maintainers may decide that violations of this code of conduct that have happened outside of the scope of the community may deem an individual unwelcome, and take appropriate action to maintain the comfort and safety of its members.
+
+As a project on GitHub, this project is additionally covered by the [GitHub Community Guidelines](https://help.github.com/articles/github-community-guidelines/).
+
+
+## Enforcement
+
+While this code of conduct should be adhered to by participants, we recognize that sometimes people may have a bad day, or be unaware of some of the guidelines in this code of conduct. When that happens, or if they are violating this code of conduct, you may reply to them and point out this code of conduct. Such messages may be in public or in private, whatever is most appropriate. However, regardless of whether the message is public or not, it should still adhere to the relevant parts of this code of conduct and itself should not be abusive or disrespectful. Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. 
+
+As a small and young project, we don’t yet have a Code of Conduct enforcement team. We encourage contributors to try to resolve issues with respectful communication - [here is an example of how to do that](https://github.com/fsprojects/fantomas/pull/649#issuecomment-599965505).
+
+Should there be difficulties in dealing with the situation or you are uncomfortable speaking up, unacceptable behavior may be reported to conduct@armadaproject.io. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+If you are unsure whether an incident is a violation, or whether the space where the incident took place is covered by our Code of Conduct, we encourage you to still address or report it. We would prefer to have a few extra reports where we decide to take no action than to let an incident go unnoticed and unresolved, resulting in an individual or group feeling like they can no longer participate in the community. Reports deemed as not a violation will also allow us to improve our Code of Conduct and processes surrounding it. 
+
+Participants asked to stop any harassing behavior are expected to comply immediately. Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## License
+
+This Code of Conduct is licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+## Attribution
+
+This Code of Conduct is informed by and adapted from multiple sources:
+
+* [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct).
+* [Auth0 Contributor Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+* [Geek Feminism Wiki Anti-Harassment Policy](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy).
+* [GitHub Community Guidelines](https://help.github.com/en/github/site-policy/github-community-guidelines).
+* [GitHub Contributor Covenant](https://www.contributor-covenant.org/).
+* [LGBTQ in Technology Slack Code of Conduct](http://lgbtq.technology/coc.html).
+* [Python Code of Conduct](https://www.python.org/psf/conduct/).
+* [Recurse Center User’s Manual](https://www.recurse.com/manual#no-feigned-surprise).
+* [Trio Code of Conduct](https://trio.readthedocs.io/en/stable/code-of-conduct.html).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+We want everyone to feel that they can contribute to the Armada Project.  Whether you have an idea to share, a feature to add, an issue to report, or a pull-request of the finest, most scintillating code ever, we want you to participate!
+
+In the sections below, you'll find some easy way to connect with other Armada developers as well as some useful informational links on our license and community policies.
+
+Looking forward to building Armada with you!
+
+## Github
+
+The Armada Operator project repository resides in Github:
+
+* [https://github.com/armadaproject/armada-operator](https://github.com/armadaproject/armada-operator)
+
+The main project fork lives here in Github:
+
+* [https://github.com/armadaproject/armada](https://github.com/armadaproject/armada)
+
+To work with [Armada website](https://armadaproject.io/), please checkout this branch:
+
+* [https://github.com/armadaproject/armada/tree/gh-pages](https://github.com/armadaproject/armada/tree/gh-pages)
+
+If you want to brainstorm a potential new feature, hop on over to the Discussions page, listed [below](#discussions).
+
+## Contributing Guide
+
+### Setup
+
+Setup everything you’ll need to get started running and developing Armada:
+
+* [Developer setup](https://armadaproject.io/developer)
+
+### Issues
+
+If you spot a bug, then please raise an issue in our main GitHub project:
+
+* [https://github.com/armadaproject/armada/issues](https://github.com/armadaproject/armada/issues)
+
+### Pull Requests
+
+Likewise, if you have developed a cool new feature or improvement, then send us a pull request.
+Please try and make sure that this is linked to an [issue](https://github.com/armadaproject/armada/issues).
+
+**Please keep all pull requests on a separate branch with proper name!**
+
+### Branches
+
+#### Squashing fix-ups
+
+Please try and squash any small commits to make the repo a bit cleaner. See a guide for doing this here:
+
+* [https://thoughtbot.com/blog/autosquashing-git-commits](https://thoughtbot.com/blog/autosquashing-git-commits)
+
+#### Branch Naming Scheme
+
+Note the names of the branch must follow proper docker names:
+
+>A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+
+## Chat & Discussions
+
+Sometimes, it's good to hash things out in real time.
+
+Armada uses GH Discussions for long form communication and design discussions. To join the conversation there, go to Discussions:
+* [https://github.com/armadaproject/armada/discussions](https://github.com/armadaproject/armada/discussions)
+
+Real-time interactions between Armada developers and users occurs primarily in CNCF Slack. To join us there:
+* If you already have an account on CNCF Slack, join #armada on [https://cloud-native.slack.com](https://cloud-native.slack.com).
+* If you need an inviation to CNCF Slack, you can get one at [https://slack.cncf.io](https://slack.cncf.io).
+
+## Security
+
+Armada developers appreciate and encourage coordinated disclosure of security vulnerabilities. If you believe you have a vulnerability to report, please contact the security team at [security@gr-oss.io](mailto:security@gr-oss.io) for triage.
+
+## License
+
+Armada is licensed with the Apache 2.0 license.  You can find it published here:
+
+* [https://github.com/armadaproject/armada/blob/master/LICENSE](https://github.com/armadaproject/armada/blob/master/LICENSE)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+# Armada Maintainers
+
+## Current
+
+| Maintainer           | GitHub ID                                               | Affiliation |
+| -------------------- | ------------------------------------------------------- | ----------- |
+| Carlo Camurri        | [carlocamurri](https://github.com/carlocamurri)         | G-Research  |
+| Sam Clark            | [samclark](https://github.com/samclark)                 | G-Research  |
+| Dave Gantenbein      | [dave-gantenbein](https://github.com/dave-gantenbein)   | G-Research  |
+| Kevin Hannon         | [kannon92](https://github.com/kannon92)                 | G-Research  |
+| Clifton Houck        | [ClifHouck](https://github.com/ClifHouck)               | G-Research  |
+| Chris Martin         | [d80tb7](https://github.com/d80tb7)                     | G-Research  |
+| James Murkin         | [JamesMurkin](https://github.com/JamesMurkin)           | G-Research  |
+| Dejan Zele Pejchev   | [dejanzele](https://github.com/dejanzele)               | G-Research  |
+| Jamie Poole          | [jimbobby5](https://github.com/jimbobby5)               | G-Research  |
+| Daniel Rastelli      | [theAntiYeti](https://github.com/theAntiYeti)           | G-Research  |
+| Alex Scammon         | [stackedsax](https://github.com/stackedsax)             | G-Research  |
+| Rich Scott           | [richscott](https://github.com/richscott)               | G-Research  |
+| Albin Severinson     | [severinson](https://github.com/severinson)             | G-Research  |
+| Geoffrey Wilson      | [suprjinx](https://github.com/suprjinx)                 | G-Research  |
+


### PR DESCRIPTION
Build Operator images using GoReleaser, then push built images to Docker Hub.

Note that the actual Docker Hub push only happens in `mainr` branch changes, so this PR will have to be merged to verify the whole build and push works. The build currently works in non-main branches, and image artifacts are successfully uploaded to GH Actions.