### PR TITLE
Fix/Enable webhooks to Run in our Dev Cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,3 +422,12 @@ dev-teardown:
 
 .PHONY: dev-run
 dev-run: dev-setup install run
+
+WEBHOOK_TLS_OUT_DIR=/tmp/k8s-webhook-server/serving-certs
+.PHONY: dev-setup-webhook-tls
+dev-setup-webhook-tls:
+	mkdir -p $(WEBHOOK_TLS_OUT_DIR)
+	openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -config dev/tls/webhooks_csr.conf -out $(WEBHOOK_TLS_OUT_DIR)/tls.crt -keyout $(WEBHOOK_TLS_OUT_DIR)/tls.key
+
+dev-remove-webhook-tls:
+	rm $(WEBHOOK_TLS_OUT_DIR)/tls.{crt,key}

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ create-dev-cluster:
 .PHONY: dev-setup
 dev-setup: create-dev-cluster helm-install-pulsar helm-install-postgres \
     helm-install-redis dev-install-prometheus-operator \
-    install-cert-manager install-ingress-controller
+    install-cert-manager install-ingress-controller dev-setup-webhook-tls
 
 .PHONY: dev-teardown
 dev-teardown:

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ go-release-build: goreleaser
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build -f Dockerfile.old -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -254,7 +254,7 @@ PROMETHEUS_OPERATOR_VERSION=v0.62.0
 .PHONY: dev-install-prometheus-operator
 dev-install-prometheus-operator:
 	curl -sL https://github.com/prometheus-operator/prometheus-operator/releases/download/${PROMETHEUS_OPERATOR_VERSION}/bundle.yaml | sed --expression='s/namespace: default/namespace: armada/g' | kubectl create -n armada -f -
-	sleep 5
+	sleep 10
 	kubectl wait --for=condition=Ready pods -l  app.kubernetes.io/name=prometheus-operator -n armada --timeout=120s
 	kubectl apply -n armada -f ./config/samples/prometheus.yaml
 
@@ -415,6 +415,9 @@ create-dev-cluster:
 dev-setup: create-dev-cluster helm-install-pulsar helm-install-postgres \
     helm-install-redis dev-install-prometheus-operator \
     install-cert-manager install-ingress-controller dev-setup-webhook-tls
+
+.PHONY: dev-install-controller
+dev-install-controller: docker-build load-image deploy
 
 .PHONY: dev-teardown
 dev-teardown:

--- a/Makefile
+++ b/Makefile
@@ -146,13 +146,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # Go Release Build
 .PHONY: go-release-build
 go-release-build: goreleaser
-	goreleaser release --rm-dist --snapshot
+	$(GORELEASER) release --rm-dist --snapshot
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -f Dockerfile.old -t ${IMG} .
+	docker build -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -417,7 +417,7 @@ dev-setup: create-dev-cluster helm-install-pulsar helm-install-postgres \
     install-cert-manager install-ingress-controller dev-setup-webhook-tls
 
 .PHONY: dev-install-controller
-dev-install-controller: docker-build load-image deploy
+dev-install-controller: go-release-build load-image deploy
 
 .PHONY: dev-teardown
 dev-teardown:

--- a/README.md
+++ b/README.md
@@ -11,24 +11,30 @@ Want to start hacking right away?
 This assumes you have [KIND](https://sigs.k8s.io/kind) installed already.
 
 Start a development cluster:
-```sh
-DISABLE_WEBHOOKS=true make dev-run
+```bash
+make dev-setup
 ```
 This will:
 - boot a kind cluster
 - start postgres, pulsar, and redis pods in the cluster
-- install each CRD supported by the armada-operator on the cluster
-- start the armada-operator main reconcilation loop for all its CRD kinds
 
-Now in another shell:
-```sh
+Then:
+```bash
+make dev-install-controller
+```
+Which will:
+- install each CRD supported by the armada-operator on the cluster
+- create a pod inside the kind cluster running the armada-operator controllers
+
+Finally:
+```bash
 kubectl apply -n armada -f $(REPO_ROOT)/config/samples/deploy_armada.yaml
 ```
 
 Which will deploy samples of each CRD.
 
-To stop the development cluster, ctrl-c your `make run` shell and then:
-```sh
+To stop the development cluster
+```bash
 make dev-teardown
 ```
 

--- a/dev/tls/webhooks_csr.conf
+++ b/dev/tls/webhooks_csr.conf
@@ -1,0 +1,13 @@
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[ dn ]
+C = US
+ST = Texas
+L = Dallas
+O = ArmadaProject
+OU = ArmadaProject Dev
+CN = armadaproject.io


### PR DESCRIPTION
So far this PR seems to enable us to execute `make run` without the need to disable webhooks. In the logs it appears that webhooks are properly registered for each kind. However, I haven't been able to gather any evidence that the webhooks are actually executing when creating resources via `kubectl apply`. Still working on that...