### PR TITLE
CI - Use pushed tag from CI workflow as input for releasing charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,25 @@ jobs:
           DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
           DOCKER_BUILDX_CACHE_FROM: "type=gha"
           DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+  chart-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set_version.outputs.version }}
+    steps:
+      - name: Set version for chart release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const headBranch = context.payload.workflow_run.head_branch;
+            console.log(headBranch)
+            core.setOutput('version', headBranch);
+        id: set_version
   invoke-chart-push:
     name: Invoke Chart push
-    needs: release
+    needs: ['release','chart-version']
     uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
+    with:
+      version: ${{ needs.chart-version.outputs.version }}
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
The current process of publishing charts is

  - CI workflow (completed) -> Release workflow (invoking publishing chart)

Within this process, an initial tag that triggered `CI` workflow was not forwarded to the `Release` workflow, therefor publishing charts were not possible as `ref` was never recieved


This PR address this issue by updating `Release` workflow and picking up a fix on the latest `invoke-push.yaml` workflow on G-Research/charts repo which is addressed within PR https://github.com/G-Research/charts/pull/114

### __NOTE__: This PR https://github.com/G-Research/charts/pull/114 should be merged before!

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-558) by [Unito](https://www.unito.io)
