### PR TITLE
ci: Fix "All required checks done" CI job to never be skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,19 @@ jobs:
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:
     name: All required checks done
+    if: ${{ always() }}
     needs:
       - lint
       - test
       - codeql
     runs-on: ubuntu-22.04
     steps:
-      - run: |
-          echo "All required checks done"
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const results = ${{ toJSON(needs.*.result) }};
+            if (results.every(res => res === 'success')) {
+              core.info('All required checks succeeded');
+            } else {
+              core.setFailed('Some required checks failed');
+            }


### PR DESCRIPTION
The "All required checks done" CI job has been designed to be a required check, but GitHub considers it successful when it's skipped, and it gets skipped when some of the jobs it depends on fail.

This PR fixes that by always running the job and checking the results of all the jobs it depends on.

Example runs:
- [all jobs successful](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5835414192)
- [some jobs failed](https://github.com/jgiannuzzi/fasttrackml/actions/runs/5835422840)

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/BATCH-659) by [Unito](https://www.unito.io)
