### PR TITLE
fix: config flag

### DIFF
--- a/internal/controller/install/common_helpers.go
+++ b/internal/controller/install/common_helpers.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	defaultPrometheusInterval = 1 * time.Second
-	appConfigFlag             = appConfigFilepath
+	appConfigFlag             = "--config"
 	appConfigFilepath         = "/config/application_config.yaml"
 )
 


### PR DESCRIPTION
Armada operator is setting args to be:

```
  containers:
  - args:
    - run
    - /config/application_config.yaml
    - /config/application_config.yaml
``` 

Where it should be

```
  containers:
  - args:
    - run
    - --config
    - /config/application_config.yaml
```

This resulted in pods failing to load the config file and reverting to defaults.