### PR TITLE
fix: segfault when resources not supplied in scheduler spec

### DIFF
--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -356,8 +356,8 @@ func createSchedulerDeployment(scheduler *installv1alpha1.Scheduler) (*appsv1.De
 
 	if scheduler.Spec.Resources != nil {
 		deployment.Spec.Template.Spec.Containers[0].Resources = *scheduler.Spec.Resources
+		deployment.Spec.Template.Spec.Containers[0].Env = addGoMemLimit(deployment.Spec.Template.Spec.Containers[0].Env, *scheduler.Spec.Resources)
 	}
-	deployment.Spec.Template.Spec.Containers[0].Env = addGoMemLimit(deployment.Spec.Template.Spec.Containers[0].Env, *scheduler.Spec.Resources)
 
 	return &deployment, nil
 }


### PR DESCRIPTION
This is a fix for a segfault that occurs when resources are nil in the scheduler spec. The current code tries to dereference `*scheduler.Spec.Resources` outside of the conditional that checks for `nil`.