### PR TITLE
feat: make ClusterIssuer optional to allow certmanager defaults

### DIFF
--- a/api/install/v1alpha1/armadaserver_types.go
+++ b/api/install/v1alpha1/armadaserver_types.go
@@ -34,7 +34,7 @@ type ArmadaServerSpec struct {
 	// An array of host names to build ingress rules for
 	HostNames []string `json:"hostNames,omitempty"`
 	// Who is issuing certificates for CA
-	ClusterIssuer string `json:"clusterIssuer"`
+	ClusterIssuer string `json:"clusterIssuer,omitempty"`
 	// Run Pulsar Init Jobs On Startup
 	PulsarInit bool `json:"pulsarInit,omitempty"`
 	// SecurityContext defines the security options the container should be run with

--- a/api/install/v1alpha1/binoculars_types.go
+++ b/api/install/v1alpha1/binoculars_types.go
@@ -58,7 +58,7 @@ type BinocularsSpec struct {
 	// An array of host names to build ingress rules for
 	HostNames []string `json:"hostNames,omitempty"`
 	// Who is issuing certificates for CA
-	ClusterIssuer string `json:"clusterIssuer"`
+	ClusterIssuer string `json:"clusterIssuer,omitempty"`
 	// SecurityContext defines the security options the container should be run with
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 	// PodSecurityContext defines the security options the pod should be run with

--- a/api/install/v1alpha1/lookout_types.go
+++ b/api/install/v1alpha1/lookout_types.go
@@ -58,7 +58,7 @@ type LookoutSpec struct {
 	// An array of host names to build ingress rules for
 	HostNames []string `json:"hostNames,omitempty"`
 	// Who is issuing certificates for CA
-	ClusterIssuer string `json:"clusterIssuer"`
+	ClusterIssuer string `json:"clusterIssuer,omitempty"`
 	// Migrate toggles whether to run migrations when installed
 	Migrate *bool `json:"migrate,omitempty"`
 	// DbPruningEnabled when true a pruning CronJob is created

--- a/api/install/v1alpha1/scheduler_types.go
+++ b/api/install/v1alpha1/scheduler_types.go
@@ -56,7 +56,7 @@ type SchedulerSpec struct {
 	// An array of host names to build ingress rules for
 	HostNames []string `json:"hostNames,omitempty"`
 	// Who is issuing certificates for CA
-	ClusterIssuer string `json:"clusterIssuer"`
+	ClusterIssuer string `json:"clusterIssuer,omitempty"`
 	// Migrate toggles whether to run migrations when installed
 	Migrate *bool `json:"migrate,omitempty"`
 	// Pruning config for cron job

--- a/config/crd/bases/install.armadaproject.io_armadaservers.yaml
+++ b/config/crd/bases/install.armadaproject.io_armadaservers.yaml
@@ -2368,7 +2368,6 @@ spec:
                 type: array
             required:
             - applicationConfig
-            - clusterIssuer
             - image
             type: object
           status:

--- a/config/crd/bases/install.armadaproject.io_binoculars.yaml
+++ b/config/crd/bases/install.armadaproject.io_binoculars.yaml
@@ -2365,7 +2365,6 @@ spec:
                 type: array
             required:
             - applicationConfig
-            - clusterIssuer
             - image
             - replicas
             type: object

--- a/config/crd/bases/install.armadaproject.io_lookouts.yaml
+++ b/config/crd/bases/install.armadaproject.io_lookouts.yaml
@@ -2374,7 +2374,6 @@ spec:
                 type: array
             required:
             - applicationConfig
-            - clusterIssuer
             - image
             type: object
           status:

--- a/config/crd/bases/install.armadaproject.io_schedulers.yaml
+++ b/config/crd/bases/install.armadaproject.io_schedulers.yaml
@@ -2434,7 +2434,6 @@ spec:
                 type: array
             required:
             - applicationConfig
-            - clusterIssuer
             - image
             type: object
           status:

--- a/internal/controller/install/armadaserver_controller.go
+++ b/internal/controller/install/armadaserver_controller.go
@@ -593,11 +593,15 @@ func createIngressGrpc(as *installv1alpha1.ArmadaServer) (*networkingv1.Ingress,
 				"kubernetes.io/ingress.class":                  as.Spec.Ingress.IngressClass,
 				"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
 				"nginx.ingress.kubernetes.io/backend-protocol": "GRPC",
-				"certmanager.k8s.io/cluster-issuer":            as.Spec.ClusterIssuer,
-				"cert-manager.io/cluster-issuer":               as.Spec.ClusterIssuer,
 			},
 		},
 	}
+
+	if as.Spec.ClusterIssuer != "" {
+		grpcIngress.ObjectMeta.Annotations["certmanager.k8s.io/cluster-issuer"] = as.Spec.ClusterIssuer
+		grpcIngress.ObjectMeta.Annotations["cert-manager.io/cluster-issuer"] = as.Spec.ClusterIssuer
+	}
+
 	if as.Spec.Ingress.Annotations != nil {
 		for key, value := range as.Spec.Ingress.Annotations {
 			grpcIngress.ObjectMeta.Annotations[key] = value
@@ -643,12 +647,15 @@ func createIngressHttp(as *installv1alpha1.ArmadaServer) (*networkingv1.Ingress,
 			Name: restIngressName, Namespace: as.Namespace, Labels: AllLabels(as.Name, as.Labels),
 			Annotations: map[string]string{
 				"kubernetes.io/ingress.class":                as.Spec.Ingress.IngressClass,
-				"certmanager.k8s.io/cluster-issuer":          as.Spec.ClusterIssuer,
-				"cert-manager.io/cluster-issuer":             as.Spec.ClusterIssuer,
 				"nginx.ingress.kubernetes.io/rewrite-target": "/$2",
 				"nginx.ingress.kubernetes.io/ssl-redirect":   "true",
 			},
 		},
+	}
+
+	if as.Spec.ClusterIssuer != "" {
+		restIngress.ObjectMeta.Annotations["certmanager.k8s.io/cluster-issuer"] = as.Spec.ClusterIssuer
+		restIngress.ObjectMeta.Annotations["cert-manager.io/cluster-issuer"] = as.Spec.ClusterIssuer
 	}
 
 	if as.Spec.Ingress.Annotations != nil {

--- a/internal/controller/install/binoculars_controller.go
+++ b/internal/controller/install/binoculars_controller.go
@@ -396,11 +396,15 @@ func createBinocularsIngressGrpc(binoculars *installv1alpha1.Binoculars) (*netwo
 				"kubernetes.io/ingress.class":                  binoculars.Spec.Ingress.IngressClass,
 				"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
 				"nginx.ingress.kubernetes.io/backend-protocol": "GRPC",
-				"certmanager.k8s.io/cluster-issuer":            binoculars.Spec.ClusterIssuer,
-				"cert-manager.io/cluster-issuer":               binoculars.Spec.ClusterIssuer,
 			},
 		},
 	}
+
+	if binoculars.Spec.ClusterIssuer != "" {
+		grpcIngress.ObjectMeta.Annotations["certmanager.k8s.io/cluster-issuer"] = binoculars.Spec.ClusterIssuer
+		grpcIngress.ObjectMeta.Annotations["cert-manager.io/cluster-issuer"] = binoculars.Spec.ClusterIssuer
+	}
+
 	if binoculars.Spec.Ingress.Annotations != nil {
 		for key, value := range binoculars.Spec.Ingress.Annotations {
 			grpcIngress.ObjectMeta.Annotations[key] = value
@@ -445,12 +449,15 @@ func createBinocularsIngressHttp(binoculars *installv1alpha1.Binoculars) (*netwo
 		ObjectMeta: metav1.ObjectMeta{Name: restIngressName, Namespace: binoculars.Namespace, Labels: AllLabels(binoculars.Name, binoculars.Labels),
 			Annotations: map[string]string{
 				"kubernetes.io/ingress.class":                binoculars.Spec.Ingress.IngressClass,
-				"certmanager.k8s.io/cluster-issuer":          binoculars.Spec.ClusterIssuer,
-				"cert-manager.io/cluster-issuer":             binoculars.Spec.ClusterIssuer,
 				"nginx.ingress.kubernetes.io/rewrite-target": "/$2",
 				"nginx.ingress.kubernetes.io/ssl-redirect":   "true",
 			},
 		},
+	}
+
+	if binoculars.Spec.ClusterIssuer != "" {
+		restIngress.ObjectMeta.Annotations["certmanager.k8s.io/cluster-issuer"] = binoculars.Spec.ClusterIssuer
+		restIngress.ObjectMeta.Annotations["cert-manager.io/cluster-issuer"] = binoculars.Spec.ClusterIssuer
 	}
 
 	if binoculars.Spec.Ingress.Annotations != nil {

--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -383,11 +383,14 @@ func createLookoutIngressHttp(lookout *installv1alpha1.Lookout) (*networking.Ing
 			Name: ingressName, Namespace: lookout.Namespace, Labels: AllLabels(lookout.Name, lookout.Labels),
 			Annotations: map[string]string{
 				"kubernetes.io/ingress.class":              lookout.Spec.Ingress.IngressClass,
-				"certmanager.k8s.io/cluster-issuer":        lookout.Spec.ClusterIssuer,
-				"cert-manager.io/cluster-issuer":           lookout.Spec.ClusterIssuer,
 				"nginx.ingress.kubernetes.io/ssl-redirect": "true",
 			},
 		},
+	}
+
+	if lookout.Spec.ClusterIssuer != "" {
+		ingressHttp.ObjectMeta.Annotations["certmanager.k8s.io/cluster-issuer"] = lookout.Spec.ClusterIssuer
+		ingressHttp.ObjectMeta.Annotations["cert-manager.io/cluster-issuer"] = lookout.Spec.ClusterIssuer
 	}
 
 	if lookout.Spec.Ingress.Annotations != nil {

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -375,10 +375,13 @@ func createSchedulerIngressGrpc(scheduler *installv1alpha1.Scheduler) (*networki
 				"kubernetes.io/ingress.class":                  scheduler.Spec.Ingress.IngressClass,
 				"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
 				"nginx.ingress.kubernetes.io/backend-protocol": "GRPC",
-				"certmanager.k8s.io/cluster-issuer":            scheduler.Spec.ClusterIssuer,
-				"cert-manager.io/cluster-issuer":               scheduler.Spec.ClusterIssuer,
 			},
 		},
+	}
+
+	if scheduler.Spec.ClusterIssuer != "" {
+		ingressHttp.ObjectMeta.Annotations["certmanager.k8s.io/cluster-issuer"] = scheduler.Spec.ClusterIssuer
+		ingressHttp.ObjectMeta.Annotations["cert-manager.io/cluster-issuer"] = scheduler.Spec.ClusterIssuer
 	}
 
 	if scheduler.Spec.Ingress.Annotations != nil {


### PR DESCRIPTION
Certmanager is capable of setting it's own default issuer. Armada operator requires that `.Spec.ClusterIssuer` is supplied and hardcodes cluster issuer annotations. This precludes the ability to rely on certmanager defaults.

This PR makes `ClusterIssuer` optional, and only attaches cluster issuer annotations when `ClusterIssuer` is supplied.