### PR TITLE
fix: Reference service accounts in deployments

### DIFF
--- a/internal/controller/install/armadaserver_controller.go
+++ b/internal/controller/install/armadaserver_controller.go
@@ -519,6 +519,7 @@ func createArmadaServerDeployment(as *installv1alpha1.ArmadaServer) (*appsv1.Dep
 					},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            as.Name,
 					TerminationGracePeriodSeconds: as.DeletionGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,

--- a/internal/controller/install/eventingester_controller.go
+++ b/internal/controller/install/eventingester_controller.go
@@ -188,6 +188,7 @@ func (r *EventIngesterReconciler) createDeployment(eventIngester *installv1alpha
 					Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(eventIngester.Spec.ApplicationConfig.Raw)},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            eventIngester.Name,
 					TerminationGracePeriodSeconds: eventIngester.Spec.TerminationGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,

--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -313,6 +313,7 @@ func createLookoutDeployment(lookout *installv1alpha1.Lookout) (*appsv1.Deployme
 					Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(lookout.Spec.ApplicationConfig.Raw)},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            lookout.Name,
 					TerminationGracePeriodSeconds: lookout.DeletionGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,

--- a/internal/controller/install/lookoutingester_controller.go
+++ b/internal/controller/install/lookoutingester_controller.go
@@ -187,6 +187,7 @@ func (r *LookoutIngesterReconciler) createDeployment(lookoutIngester *installv1a
 					Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(lookoutIngester.Spec.ApplicationConfig.Raw)},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            lookoutIngester.Name,
 					TerminationGracePeriodSeconds: lookoutIngester.Spec.TerminationGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"k8s.io/utils/ptr"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -197,7 +199,18 @@ func generateSchedulerInstallComponents(scheduler *installv1alpha1.Scheduler, sc
 	if err := controllerutil.SetOwnerReference(scheduler, secret, scheme); err != nil {
 		return nil, err
 	}
-	deployment, err := createSchedulerDeployment(scheduler)
+
+	var serviceAccount *corev1.ServiceAccount
+	serviceAccountName := scheduler.Spec.CustomServiceAccount
+	if serviceAccountName == "" {
+		serviceAccount = builders.CreateServiceAccount(scheduler.Name, scheduler.Namespace, AllLabels(scheduler.Name, scheduler.Labels), scheduler.Spec.ServiceAccount)
+		if err = controllerutil.SetOwnerReference(scheduler, serviceAccount, scheme); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		serviceAccountName = serviceAccount.Name
+	}
+
+	deployment, err := createSchedulerDeployment(scheduler, serviceAccountName)
 	if err != nil {
 		return nil, err
 	}
@@ -207,10 +220,6 @@ func generateSchedulerInstallComponents(scheduler *installv1alpha1.Scheduler, sc
 
 	service := builders.Service(scheduler.Name, scheduler.Namespace, AllLabels(scheduler.Name, scheduler.Labels), IdentityLabel(scheduler.Name), scheduler.Spec.PortConfig)
 	if err := controllerutil.SetOwnerReference(scheduler, service, scheme); err != nil {
-		return nil, err
-	}
-	serviceAccount := builders.CreateServiceAccount(scheduler.Name, scheduler.Namespace, AllLabels(scheduler.Name, scheduler.Labels), scheduler.Spec.ServiceAccount)
-	if err := controllerutil.SetOwnerReference(scheduler, serviceAccount, scheme); err != nil {
 		return nil, err
 	}
 
@@ -284,7 +293,7 @@ func createSchedulerServiceMonitor(scheduler *installv1alpha1.Scheduler) *monito
 
 // Function to build the deployment object for Scheduler.
 // This should be changing from CRD to CRD.  Not sure if generailize this helps much
-func createSchedulerDeployment(scheduler *installv1alpha1.Scheduler) (*appsv1.Deployment, error) {
+func createSchedulerDeployment(scheduler *installv1alpha1.Scheduler, serviceAccountName string) (*appsv1.Deployment, error) {
 	var runAsUser int64 = 1000
 	var runAsGroup int64 = 2000
 	allowPrivilegeEscalation := false
@@ -307,7 +316,7 @@ func createSchedulerDeployment(scheduler *installv1alpha1.Scheduler) (*appsv1.De
 					Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(scheduler.Spec.ApplicationConfig.Raw)},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:            scheduler.Name,
+					ServiceAccountName:            serviceAccountName,
 					TerminationGracePeriodSeconds: scheduler.DeletionGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -307,6 +307,7 @@ func createSchedulerDeployment(scheduler *installv1alpha1.Scheduler) (*appsv1.De
 					Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(scheduler.Spec.ApplicationConfig.Raw)},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            scheduler.Name,
 					TerminationGracePeriodSeconds: scheduler.DeletionGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,

--- a/internal/controller/install/scheduleringester_controller.go
+++ b/internal/controller/install/scheduleringester_controller.go
@@ -188,6 +188,7 @@ func (r *SchedulerIngesterReconciler) createDeployment(scheduleringester *instal
 					Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(scheduleringester.Spec.ApplicationConfig.Raw)},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            scheduleringester.Name,
 					TerminationGracePeriodSeconds: scheduleringester.Spec.TerminationGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,


### PR DESCRIPTION
We ran into issues where we were specifying image pull secrets for service accounts but they were not effective since the deployments did not reference the service accounts.

Unfortunately the unit tests use pretty broad mock assertions so this does not impact the unit tests.