### PR TITLE
fix: Actually reconcile service accounts

### DIFF
--- a/internal/controller/install/common_helpers.go
+++ b/internal/controller/install/common_helpers.go
@@ -152,6 +152,16 @@ func (cc *CommonComponents) ReconcileComponents(newComponents *CommonComponents)
 		cc.Service = nil
 	}
 
+	if newComponents.ServiceAccount != nil {
+		cc.ServiceAccount.Labels = newComponents.ServiceAccount.Labels
+		cc.ServiceAccount.Annotations = newComponents.ServiceAccount.Annotations
+		cc.ServiceAccount.ImagePullSecrets = newComponents.ServiceAccount.ImagePullSecrets
+		cc.ServiceAccount.Secrets = newComponents.ServiceAccount.Secrets
+		cc.ServiceAccount.AutomountServiceAccountToken = newComponents.ServiceAccount.AutomountServiceAccountToken
+	} else {
+		cc.ServiceAccount = nil
+	}
+
 	if newComponents.ClusterRole != nil {
 		cc.ClusterRole.Rules = newComponents.ClusterRole.Rules
 		cc.ClusterRole.Labels = newComponents.ClusterRole.Labels

--- a/internal/controller/install/common_helpers_test.go
+++ b/internal/controller/install/common_helpers_test.go
@@ -759,6 +759,27 @@ func makeCommonComponents() CommonComponents {
 		},
 	}
 
+	automountServiceAccountToken := true
+	serviceAccount := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "some-name",
+			Namespace:   "some-namespace",
+			Labels:      map[string]string{"some-label-key": "some-label-value"},
+			Annotations: map[string]string{"some-annotation-key": "some-annotation-value"},
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{
+				Name: "some-image-pull-secret",
+			},
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Name: "some-secret",
+			},
+		},
+		AutomountServiceAccountToken: &automountServiceAccountToken,
+	}
+
 	pc := schedulingv1.PriorityClass{
 		Value: 1000,
 	}
@@ -768,6 +789,7 @@ func makeCommonComponents() CommonComponents {
 	}
 	return CommonComponents{
 		Deployment:      &deployment,
+		ServiceAccount:  &serviceAccount,
 		PriorityClasses: []*schedulingv1.PriorityClass{&pc},
 		Secret:          &secret,
 	}


### PR DESCRIPTION
c# Pull Request Template

## Description

This is a follow up to https://github.com/armadaproject/armada-operator/pull/316

Even after those changes we found the armada operator controller wasn't syncing image pull secrets to service accounts that it created. After looking further I noticed that the reconciliation code does nothing with service accounts.

Fixes # (issue)

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?

Unit test added and tested on k8s 1.29

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
