### PR TITLE
fix: Run migrations with service accounts

### DIFF
--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -237,7 +237,7 @@ func generateLookoutInstallComponents(lookout *installv1alpha1.Lookout, scheme *
 		}
 	}
 
-	job, err := createLookoutMigrationJob(lookout)
+	job, err := createLookoutMigrationJob(lookout, serviceAccountName)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +440,7 @@ func createLookoutIngressHttp(lookout *installv1alpha1.Lookout) (*networking.Ing
 }
 
 // createLookoutMigrationJob returns a batch Job or an error if the app config is not correct
-func createLookoutMigrationJob(lookout *installv1alpha1.Lookout) (*batchv1.Job, error) {
+func createLookoutMigrationJob(lookout *installv1alpha1.Lookout, serviceAccountName string) (*batchv1.Job, error) {
 	runAsUser := int64(1000)
 	runAsGroup := int64(2000)
 	var terminationGracePeriodSeconds int64
@@ -483,6 +483,7 @@ func createLookoutMigrationJob(lookout *installv1alpha1.Lookout) (*batchv1.Job, 
 					Labels:    AllLabels(lookout.Name, lookout.Labels),
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            serviceAccountName,
 					RestartPolicy:                 "Never",
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{

--- a/internal/controller/install/lookout_controller_test.go
+++ b/internal/controller/install/lookout_controller_test.go
@@ -491,6 +491,7 @@ func Test_createLookoutMigrationJob(t *testing.T) {
 				assert.Equal(t, "postgres3000", job.Spec.Template.Spec.InitContainers[0].Env[0].Value)
 				assert.Equal(t, "PGPORT", job.Spec.Template.Spec.InitContainers[0].Env[1].Name)
 				assert.Equal(t, "4000", job.Spec.Template.Spec.InitContainers[0].Env[1].Value)
+				assert.Equal(t, "sa", job.Spec.Template.Spec.ServiceAccountName)
 			},
 			wantErr: false,
 		},
@@ -508,6 +509,7 @@ func Test_createLookoutMigrationJob(t *testing.T) {
 				assert.Equal(t, "", job.Spec.Template.Spec.InitContainers[0].Env[0].Value)
 				assert.Equal(t, "PGPORT", job.Spec.Template.Spec.InitContainers[0].Env[1].Name)
 				assert.Equal(t, "", job.Spec.Template.Spec.InitContainers[0].Env[1].Value)
+				assert.Equal(t, "sa", job.Spec.Template.Spec.ServiceAccountName)
 			},
 			wantErr: false,
 		},
@@ -532,7 +534,7 @@ func Test_createLookoutMigrationJob(t *testing.T) {
 			if tt.modifyInput != nil {
 				tt.modifyInput(&cr)
 			}
-			rslt, err := createLookoutMigrationJob(&cr, "")
+			rslt, err := createLookoutMigrationJob(&cr, "sa")
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/controller/install/lookout_controller_test.go
+++ b/internal/controller/install/lookout_controller_test.go
@@ -532,7 +532,7 @@ func Test_createLookoutMigrationJob(t *testing.T) {
 			if tt.modifyInput != nil {
 				tt.modifyInput(&cr)
 			}
-			rslt, err := createLookoutMigrationJob(&cr)
+			rslt, err := createLookoutMigrationJob(&cr, "")
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -231,7 +231,7 @@ func generateSchedulerInstallComponents(scheduler *installv1alpha1.Scheduler, sc
 		}
 	}
 
-	job, err := createSchedulerMigrationJob(scheduler)
+	job, err := createSchedulerMigrationJob(scheduler, serviceAccountName)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func createSchedulerIngressGrpc(scheduler *installv1alpha1.Scheduler) (*networki
 }
 
 // createSchedulerMigrationJob returns a batch Job or an error if the app config is not correct
-func createSchedulerMigrationJob(scheduler *installv1alpha1.Scheduler) (*batchv1.Job, error) {
+func createSchedulerMigrationJob(scheduler *installv1alpha1.Scheduler, serviceAccountName string) (*batchv1.Job, error) {
 	runAsUser := int64(1000)
 	runAsGroup := int64(2000)
 	var terminationGracePeriodSeconds int64
@@ -474,6 +474,7 @@ func createSchedulerMigrationJob(scheduler *installv1alpha1.Scheduler) (*batchv1
 					Labels:    AllLabels(scheduler.Name, scheduler.Labels),
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            serviceAccountName,
 					RestartPolicy:                 "Never",
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					SecurityContext: &corev1.PodSecurityContext{

--- a/internal/controller/install/scheduler_controller_test.go
+++ b/internal/controller/install/scheduler_controller_test.go
@@ -713,6 +713,7 @@ func Test_createSchedulerMigrationJob(t *testing.T) {
 				assert.Equal(t, "postgres3000", job.Spec.Template.Spec.InitContainers[0].Env[0].Value)
 				assert.Equal(t, "PGPORT", job.Spec.Template.Spec.InitContainers[0].Env[1].Name)
 				assert.Equal(t, "4000", job.Spec.Template.Spec.InitContainers[0].Env[1].Value)
+				assert.Equal(t, "sa", job.Spec.Template.Spec.ServiceAccountName)
 			},
 			wantErr: false,
 		},
@@ -730,6 +731,7 @@ func Test_createSchedulerMigrationJob(t *testing.T) {
 				assert.Equal(t, "", job.Spec.Template.Spec.InitContainers[0].Env[0].Value)
 				assert.Equal(t, "PGPORT", job.Spec.Template.Spec.InitContainers[0].Env[1].Name)
 				assert.Equal(t, "", job.Spec.Template.Spec.InitContainers[0].Env[1].Value)
+				assert.Equal(t, "sa", job.Spec.Template.Spec.ServiceAccountName)
 			},
 			wantErr: false,
 		},
@@ -754,7 +756,7 @@ func Test_createSchedulerMigrationJob(t *testing.T) {
 			if tt.modifyInput != nil {
 				tt.modifyInput(&cr)
 			}
-			rslt, err := createSchedulerMigrationJob(&cr, "")
+			rslt, err := createSchedulerMigrationJob(&cr, "sa")
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/controller/install/scheduler_controller_test.go
+++ b/internal/controller/install/scheduler_controller_test.go
@@ -754,7 +754,7 @@ func Test_createSchedulerMigrationJob(t *testing.T) {
 			if tt.modifyInput != nil {
 				tt.modifyInput(&cr)
 			}
-			rslt, err := createSchedulerMigrationJob(&cr)
+			rslt, err := createSchedulerMigrationJob(&cr, "")
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
## Description
We run a fork of lookout with custom schema migrations and we had issues with k8s pulling our custom image because the service account configurations were not propagated to the migration pods. 

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?

Tested with a custom lookout image in our container registry and a service account with image pull secrets.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
