### PR TITLE
fix: add pulsar config volume mount in scheduler

### DIFF
--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -298,8 +298,14 @@ func createSchedulerDeployment(scheduler *installv1alpha1.Scheduler, serviceAcco
 	var runAsGroup int64 = 2000
 	allowPrivilegeEscalation := false
 	env := createEnv(scheduler.Spec.Environment)
+	pulsarConfig, err := ExtractPulsarConfig(scheduler.Spec.ApplicationConfig)
+	if err != nil {
+		return nil, err
+	}
 	volumes := createVolumes(scheduler.Name, scheduler.Spec.AdditionalVolumes)
+	volumes = append(volumes, createPulsarVolumes(pulsarConfig)...)
 	volumeMounts := createVolumeMounts(GetConfigFilename(scheduler.Name), scheduler.Spec.AdditionalVolumeMounts)
+	volumeMounts = append(volumeMounts, createPulsarVolumeMounts(pulsarConfig)...)
 
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: scheduler.Name, Namespace: scheduler.Namespace, Labels: AllLabels(scheduler.Name, scheduler.Labels)},


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the changes and the related issue (if any). Describe your changes in detail to help reviewers understand your contribution.

- **What is the purpose of this PR?**

This PR fixes the issue where the scheduler installed by the operator misses the Pulsar config in order to authenticate to Pulsar.

- **What was changed?**

This PR adds the Pulsar volume and volume mount to the scheduler deployment in the scheduler controller.

- **Why was it changed?**

The change is because of the missing Pulsar config in the scheduler deployment, when Pulsar config is specified in Application config.

- **Does this address any existing issues or enhancement requests?**

This PR addresses an existing issue.

Fixes # (issue)

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions to reproduce these tests. List any relevant details for your test configuration.

- **Test Configuration**:
    - Kubernetes Version: v1.28.3
    - Helm Version: v3.15.1
    - OS: Ubuntu 22.04

- **Test Steps**:
    1. make test-unit
    2. make test-integration
    3. install armada-operator and armada in a Kubernetes cluster, and the scheduler is able to authenticate to Pulsar.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
