### PR TITLE
fix: Update pruning pods to use different labels and add unit test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.23.2
 require (
 	github.com/go-logr/logr v1.4.2
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.6.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.77.2
 	github.com/stretchr/testify v1.9.0
+	google.golang.org/protobuf v1.35.1
 	k8s.io/api v0.31.2
 	k8s.io/apimachinery v0.31.2
 	k8s.io/client-go v0.31.2
@@ -36,7 +38,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -66,7 +67,6 @@ require (
 	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.26.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
-	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -468,20 +468,22 @@ func createLookoutCronJob(lookout *installv1alpha1.Lookout, serviceAccountName s
 		return nil, err
 	}
 
+	name := lookout.Name + "-db-pruner"
+
 	job := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        lookout.Name + "-db-pruner",
+			Name:        name,
 			Namespace:   lookout.Namespace,
-			Labels:      AllLabels(lookout.Name, lookout.Labels),
+			Labels:      AllLabels(name, lookout.Labels),
 			Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(lookout.Spec.ApplicationConfig.Raw)},
 		},
 		Spec: batchv1.CronJobSpec{
 			Schedule: dbPruningSchedule,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      lookout.Name + "-db-pruner",
+					Name:      name,
 					Namespace: lookout.Namespace,
-					Labels:    AllLabels(lookout.Name, lookout.Labels),
+					Labels:    AllLabels(name, lookout.Labels),
 				},
 				Spec: batchv1.JobSpec{
 					Parallelism:  &parallelism,
@@ -489,9 +491,9 @@ func createLookoutCronJob(lookout *installv1alpha1.Lookout, serviceAccountName s
 					BackoffLimit: &backoffLimit,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      lookout.Name + "-db-pruner",
+							Name:      name,
 							Namespace: lookout.Namespace,
-							Labels:    AllLabels(lookout.Name, lookout.Labels),
+							Labels:    AllLabels(name, lookout.Labels),
 						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName:            serviceAccountName,
@@ -522,7 +524,7 @@ func createLookoutCronJob(lookout *installv1alpha1.Lookout, serviceAccountName s
 								},
 							}},
 							Containers: []corev1.Container{{
-								Name:            "lookout-db-pruner",
+								Name:            name,
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Image:           ImageString(lookout.Spec.Image),
 								Args: []string{

--- a/internal/controller/install/lookout_controller_test.go
+++ b/internal/controller/install/lookout_controller_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
 	"github.com/armadaproject/armada-operator/internal/controller/builders"
 
 	"k8s.io/utils/ptr"
@@ -342,6 +345,155 @@ func TestLookoutReconciler_CreateCronJobErrorDueToApplicationConfig(t *testing.T
 	_, err := createLookoutCronJob(&expectedLookout, "lookout")
 	assert.Error(t, err)
 	assert.Equal(t, "yaml: line 1: did not find expected ',' or '}'", err.Error())
+}
+
+func TestLookoutReconciler_CreateCronJob(t *testing.T) {
+	t.Parallel()
+
+	dbPruningEnabled := true
+	dbPruningSchedule := "1d"
+
+	lookout := v1alpha1.Lookout{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Lookout",
+			APIVersion: "install.armadaproject.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "lookout",
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:        []string{operatorFinalizer},
+		},
+		Spec: v1alpha1.LookoutSpec{
+			CommonSpecBase: installv1alpha1.CommonSpecBase{
+				Labels: nil,
+				Image: v1alpha1.Image{
+					Repository: "testrepo",
+					Tag:        "1.0.0",
+				},
+				ApplicationConfig: runtime.RawExtension{Raw: []byte(`{}`)},
+				Resources:         &corev1.ResourceRequirements{},
+			},
+			Replicas:      ptr.To[int32](2),
+			ClusterIssuer: "test",
+			Ingress: &v1alpha1.IngressConfig{
+				IngressClass: "nginx",
+			},
+			DbPruningEnabled:  &dbPruningEnabled,
+			DbPruningSchedule: &dbPruningSchedule,
+		},
+	}
+	cronJob, err := createLookoutCronJob(&lookout, "lookout")
+	assert.NoError(t, err)
+
+	var expectedParallelism int32 = 1
+	var expectedCompletions int32 = 1
+	var expectedBackoffLimit int32 = 0
+	var expectedTerminationGracePeriodSeconds int64 = 0
+
+	expectedCronJob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lookout-db-pruner",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":     "lookout-db-pruner",
+				"release": "lookout-db-pruner",
+			},
+			Annotations: map[string]string{
+				"checksum/config": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+			},
+		},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lookout-db-pruner",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":     "lookout-db-pruner",
+						"release": "lookout-db-pruner",
+					},
+				},
+				Spec: batchv1.JobSpec{
+					Parallelism:  &expectedParallelism,
+					Completions:  &expectedCompletions,
+					BackoffLimit: &expectedBackoffLimit,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "lookout-db-pruner",
+							Namespace: "default",
+							Labels: map[string]string{
+								"app":     "lookout-db-pruner",
+								"release": "lookout-db-pruner",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Args: []string{
+										"--pruneDatabase",
+										"--config",
+										"/config/application_config.yaml",
+									},
+									Image:           "testrepo:1.0.0",
+									ImagePullPolicy: "IfNotPresent",
+									Name:            "lookout-db-pruner",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "user-config",
+											ReadOnly:  true,
+											MountPath: appConfigFilepath,
+											SubPath:   "lookout-config.yaml",
+										},
+									},
+								},
+							},
+							InitContainers: []corev1.Container{
+								{
+									Name:  "lookout-db-pruner-db-wait",
+									Image: "alpine:3.10",
+									Command: []string{
+										"/bin/sh",
+										"-c",
+										`echo "Waiting for Postres..."
+                                                         while ! nc -z $PGHOST $PGPORT; do
+                                                           sleep 1
+                                                         done
+                                                         echo "Postres started!"`,
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "PGHOST",
+										},
+										{
+											Name: "PGPORT",
+										},
+									},
+								},
+							},
+							RestartPolicy:                 "Never",
+							ServiceAccountName:            "lookout",
+							TerminationGracePeriodSeconds: &expectedTerminationGracePeriodSeconds,
+							Volumes: []corev1.Volume{
+								{
+									Name: "user-config",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "lookout",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Schedule: "1d",
+		},
+	}
+
+	if !cmp.Equal(expectedCronJob, cronJob, protocmp.Transform()) {
+		t.Fatalf("cronjob is not the same %s", cmp.Diff(expectedCronJob, cronJob, protocmp.Transform()))
+	}
 }
 
 func TestLookoutReconciler_ReconcileDeletingLookout(t *testing.T) {

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -503,11 +503,13 @@ func newSchedulerCronJob(scheduler *installv1alpha1.Scheduler, serviceAccountNam
 		prunerResources = *scheduler.Spec.Pruner.Resources
 	}
 
+	name := scheduler.Name + "-db-pruner"
+
 	job := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        scheduler.Name + "-db-pruner",
+			Name:        name,
 			Namespace:   scheduler.Namespace,
-			Labels:      AllLabels(scheduler.Name, scheduler.Labels),
+			Labels:      AllLabels(name, scheduler.Labels),
 			Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(scheduler.Spec.ApplicationConfig.Raw)},
 		},
 		Spec: batchv1.CronJobSpec{
@@ -515,9 +517,9 @@ func newSchedulerCronJob(scheduler *installv1alpha1.Scheduler, serviceAccountNam
 			Schedule: scheduler.Spec.Pruner.Schedule,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      scheduler.Name + "-db-pruner",
+					Name:      name,
 					Namespace: scheduler.Namespace,
-					Labels:    AllLabels(scheduler.Name, scheduler.Labels),
+					Labels:    AllLabels(name, scheduler.Labels),
 				},
 				Spec: batchv1.JobSpec{
 					Parallelism:  &parallelism,
@@ -525,9 +527,9 @@ func newSchedulerCronJob(scheduler *installv1alpha1.Scheduler, serviceAccountNam
 					BackoffLimit: &backoffLimit,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      scheduler.Name + "-db-pruner",
+							Name:      name,
 							Namespace: scheduler.Namespace,
-							Labels:    AllLabels(scheduler.Name, scheduler.Labels),
+							Labels:    AllLabels(name, scheduler.Labels),
 						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName:            serviceAccountName,
@@ -558,7 +560,7 @@ func newSchedulerCronJob(scheduler *installv1alpha1.Scheduler, serviceAccountNam
 								},
 							}},
 							Containers: []corev1.Container{{
-								Name:            "scheduler-db-pruner",
+								Name:            name,
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Image:           ImageString(scheduler.Spec.Image),
 								Args:            prunerArgs,


### PR DESCRIPTION
# Pull Request Template

Fixes #335

Also introduces `protocmp` as a way to make assertions on entire proto structs instead of cherry picking assertions on individual fields. This should make unit test much more robust moving forward if used.

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?

See new unit tests

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
