### PR TITLE
fix: Delete cronjobs when pruning disabled and actually reconcile scheduler corncobs

### DIFF
--- a/internal/controller/install/common_helpers.go
+++ b/internal/controller/install/common_helpers.go
@@ -622,7 +622,7 @@ func isNil(i any) bool {
 // deleteObjectIfNeeded will delete the object if it exists.
 func deleteObjectIfNeeded(
 	ctx context.Context,
-	client client.Client,
+	k8sClient client.Client,
 	object client.Object,
 	componentName string,
 	logger logr.Logger,
@@ -631,13 +631,8 @@ func deleteObjectIfNeeded(
 		return nil
 	}
 
-	err := client.Delete(ctx, object)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil // nothing to do
-		} else {
-			return err
-		}
+	if err := k8sClient.Delete(ctx, object); err != nil {
+		return client.IgnoreNotFound(err)
 	}
 
 	logger.Info("Successfully deleted %s %s", componentName, object.GetObjectKind())

--- a/internal/controller/install/common_helpers.go
+++ b/internal/controller/install/common_helpers.go
@@ -596,13 +596,13 @@ func upsertObjectIfNeeded(
 	mutateFn controllerutil.MutateFn,
 	logger logr.Logger,
 ) error {
-	if !isNil(object) {
-		logger.Info(fmt.Sprintf("Upserting %s %s object", componentName, object.GetObjectKind()))
-		if _, err := controllerutil.CreateOrUpdate(ctx, client, object, mutateFn); err != nil {
-			return err
-		}
+	if isNil(object) {
+		return nil
 	}
-	return nil
+
+	logger.Info(fmt.Sprintf("Upserting %s %s object", componentName, object.GetObjectKind()))
+	_, err := controllerutil.CreateOrUpdate(ctx, client, object, mutateFn)
+	return err
 }
 
 // Helper function to determine if the object is nil even if it's a pointer to a nil value
@@ -617,6 +617,32 @@ func isNil(i any) bool {
 	default:
 		return false
 	}
+}
+
+// deleteObjectIfNeeded will delete the object if it exists.
+func deleteObjectIfNeeded(
+	ctx context.Context,
+	client client.Client,
+	object client.Object,
+	componentName string,
+	logger logr.Logger,
+) error {
+	if isNil(object) {
+		return nil
+	}
+
+	err := client.Delete(ctx, object)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil // nothing to do
+		} else {
+			return err
+		}
+	}
+
+	logger.Info("Successfully deleted %s %s", componentName, object.GetObjectKind())
+
+	return nil
 }
 
 // getObject will get the object from Kubernetes and return if it is missing or an error.

--- a/internal/controller/install/scheduler_controller_test.go
+++ b/internal/controller/install/scheduler_controller_test.go
@@ -187,6 +187,7 @@ func TestSchedulerReconciler_Reconcile(t *testing.T) {
 		Create(gomock.Any(), gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})).
 		Return(nil)
 
+	// PrometheusRule
 	mockK8sClient.
 		EXPECT().
 		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})).
@@ -194,6 +195,208 @@ func TestSchedulerReconciler_Reconcile(t *testing.T) {
 	mockK8sClient.
 		EXPECT().
 		Create(gomock.Any(), gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})).
+		Return(nil)
+
+	// CronJob
+	expectedCronJobName := expectedNamespacedName
+	expectedCronJobName.Name = expectedCronJobName.Name + "-db-pruner"
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedCronJobName, gomock.AssignableToTypeOf(&batchv1.CronJob{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "armadaserver"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&batchv1.CronJob{})).
+		Return(nil)
+
+	r := SchedulerReconciler{
+		Client: mockK8sClient,
+		Scheme: scheme,
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "scheduler"},
+	}
+
+	_, err = r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("reconcile should not return error")
+	}
+}
+
+func TestSchedulerReconciler_ReconcilePruningDisabled(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	scheme, err := v1alpha1.SchemeBuilder.Build()
+	if err != nil {
+		t.Fatalf("should not return error when building schema")
+	}
+
+	expectedNamespacedName := types.NamespacedName{Namespace: "default", Name: "scheduler"}
+	dbPruningEnabled := false
+	dbPruningSchedule := "1d"
+	terminationGracePeriod := int64(20)
+	expectedScheduler := v1alpha1.Scheduler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Scheduler",
+			APIVersion: "install.armadaproject.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "scheduler"},
+		Spec: v1alpha1.SchedulerSpec{
+			Replicas: ptr.To[int32](2),
+			CommonSpecBase: installv1alpha1.CommonSpecBase{
+				Labels: nil,
+				Image: v1alpha1.Image{
+					Repository: "testrepo",
+					Tag:        "1.0.0",
+				},
+				ApplicationConfig:             runtime.RawExtension{},
+				Resources:                     &corev1.ResourceRequirements{},
+				Prometheus:                    &installv1alpha1.PrometheusConfig{Enabled: true, ScrapeInterval: &metav1.Duration{Duration: 1 * time.Second}},
+				TerminationGracePeriodSeconds: &terminationGracePeriod,
+			},
+			ClusterIssuer: "test",
+			HostNames:     []string{"localhost"},
+			Ingress: &installv1alpha1.IngressConfig{
+				IngressClass: "nginx",
+				Labels:       map[string]string{"test": "hello"},
+				Annotations:  map[string]string{"test": "hello"},
+			},
+			Pruner: &installv1alpha1.PrunerConfig{
+				Enabled:  dbPruningEnabled,
+				Schedule: dbPruningSchedule,
+			},
+		},
+	}
+
+	commonConfig, err := builders.ParseCommonApplicationConfig(expectedScheduler.Spec.ApplicationConfig)
+	if err != nil {
+		t.Fatalf("should not return error when parsing common application config")
+	}
+	scheduler, err := generateSchedulerInstallComponents(&expectedScheduler, scheme, commonConfig)
+	if err != nil {
+		t.Fatal("We should not fail on generating scheduler")
+	}
+
+	mockK8sClient := k8sclient.NewMockClient(mockCtrl)
+	// Scheduler
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&v1alpha1.Scheduler{})).
+		Return(nil).
+		SetArg(2, expectedScheduler)
+
+	// Finalizer
+	mockK8sClient.
+		EXPECT().
+		Update(gomock.Any(), gomock.AssignableToTypeOf(&installv1alpha1.Scheduler{})).
+		Return(nil)
+
+	// ServiceAccount
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&corev1.ServiceAccount{})).
+		Return(nil).
+		SetArg(1, *scheduler.ServiceAccount)
+
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+		Return(nil).
+		SetArg(1, *scheduler.Secret)
+
+	expectedJobName := types.NamespacedName{Namespace: "default", Name: "scheduler-migration"}
+	scheduler.Jobs[0].Status = batchv1.JobStatus{
+		Conditions: []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}},
+	}
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedJobName, gomock.AssignableToTypeOf(&batchv1.Job{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&batchv1.Job{})).
+		Return(nil).
+		SetArg(1, *scheduler.Jobs[0])
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedJobName, gomock.AssignableToTypeOf(&batchv1.Job{})).
+		Return(nil).
+		SetArg(2, *scheduler.Jobs[0])
+
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&appsv1.Deployment{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.Deployment{})).
+		Return(nil).
+		SetArg(1, *scheduler.Deployment)
+
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&corev1.Service{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Service{})).
+		Return(nil).
+		SetArg(1, *scheduler.Service)
+
+	// IngressGrpc
+	expectedIngressName := expectedNamespacedName
+	expectedIngressName.Name = expectedIngressName.Name + "-grpc"
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedIngressName, gomock.AssignableToTypeOf(&networkingv1.Ingress{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&networkingv1.Ingress{})).
+		Return(nil).
+		SetArg(1, *scheduler.IngressGrpc)
+
+	// ServiceMonitor
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})).
+		Return(nil)
+
+	// PrometheusRule
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "scheduler"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})).
+		Return(nil)
+
+	// CronJob
+	expectedCronJobName := expectedNamespacedName
+	expectedCronJobName.Name = expectedCronJobName.Name + "-db-pruner"
+	mockK8sClient.
+		EXPECT().
+		Delete(gomock.Any(), gomock.AssignableToTypeOf(&batchv1.CronJob{})).
 		Return(nil)
 
 	r := SchedulerReconciler{
@@ -459,6 +662,7 @@ func TestSchedulerReconciler_ReconcileMissingResources(t *testing.T) {
 		Create(gomock.Any(), gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})).
 		Return(nil)
 
+	// PrometheusRule
 	mockK8sClient.
 		EXPECT().
 		Get(gomock.Any(), expectedNamespacedName, gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})).
@@ -466,6 +670,18 @@ func TestSchedulerReconciler_ReconcileMissingResources(t *testing.T) {
 	mockK8sClient.
 		EXPECT().
 		Create(gomock.Any(), gomock.AssignableToTypeOf(&monitoringv1.PrometheusRule{})).
+		Return(nil)
+
+	// CronJob
+	expectedCronJobName := expectedNamespacedName
+	expectedCronJobName.Name = expectedCronJobName.Name + "-db-pruner"
+	mockK8sClient.
+		EXPECT().
+		Get(gomock.Any(), expectedCronJobName, gomock.AssignableToTypeOf(&batchv1.CronJob{})).
+		Return(errors.NewNotFound(schema.GroupResource{}, "armadaserver"))
+	mockK8sClient.
+		EXPECT().
+		Create(gomock.Any(), gomock.AssignableToTypeOf(&batchv1.CronJob{})).
 		Return(nil)
 
 	r := SchedulerReconciler{


### PR DESCRIPTION
Fixes #337 

* Reconcile scheduler pruner cron jobs
* Update logic to delete previously enabled cron jobs when pruning is disabled. Otherwise, disabling pruning does nothing and the jobs will continue to run.

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?
See unit tests. 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
