### PR TITLE
fix: Add liveness and readiness probes

### DIFF
--- a/internal/controller/install/armadaserver_controller.go
+++ b/internal/controller/install/armadaserver_controller.go
@@ -449,6 +449,13 @@ func createArmadaServerDeployment(
 	volumeMounts := createVolumeMounts(GetConfigFilename(as.Name), as.Spec.AdditionalVolumeMounts)
 	volumeMounts = append(volumeMounts, createPulsarVolumeMounts(pulsarConfig)...)
 
+	asConfig, err := extractArmadaServerConfig(as.Spec.ApplicationConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(asConfig.Grpc.Tls))
+
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      as.Name,
@@ -483,6 +490,8 @@ func createArmadaServerDeployment(
 						Env:             env,
 						VolumeMounts:    volumeMounts,
 						SecurityContext: as.Spec.SecurityContext,
+						ReadinessProbe:  readinessProbe,
+						LivenessProbe:   livenessProbe,
 					}},
 					Volumes: volumes,
 				},
@@ -677,4 +686,22 @@ func createServerPrometheusRule(server *installv1alpha1.ArmadaServer) *monitorin
 			}},
 		},
 	}
+}
+
+type ArmadaServerConfig struct {
+	Grpc GrpcConfig
+}
+
+// extractArmadaServerConfig will unmarshal the appconfig and return the AramadaServerConfig portion
+func extractArmadaServerConfig(config runtime.RawExtension) (ArmadaServerConfig, error) {
+	appConfig, err := builders.ConvertRawExtensionToYaml(config)
+	if err != nil {
+		return ArmadaServerConfig{}, err
+	}
+	var asConfig ArmadaServerConfig
+	err = yaml.Unmarshal([]byte(appConfig), &asConfig)
+	if err != nil {
+		return ArmadaServerConfig{}, err
+	}
+	return asConfig, err
 }

--- a/internal/controller/install/armadaserver_controller.go
+++ b/internal/controller/install/armadaserver_controller.go
@@ -449,12 +449,7 @@ func createArmadaServerDeployment(
 	volumeMounts := createVolumeMounts(GetConfigFilename(as.Name), as.Spec.AdditionalVolumeMounts)
 	volumeMounts = append(volumeMounts, createPulsarVolumeMounts(pulsarConfig)...)
 
-	asConfig, err := extractArmadaServerConfig(as.Spec.ApplicationConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(asConfig.Grpc.Tls))
+	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(commonConfig.GRPC.TLS))
 
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -686,22 +681,4 @@ func createServerPrometheusRule(server *installv1alpha1.ArmadaServer) *monitorin
 			}},
 		},
 	}
-}
-
-type ArmadaServerConfig struct {
-	Grpc GrpcConfig
-}
-
-// extractArmadaServerConfig will unmarshal the appconfig and return the AramadaServerConfig portion
-func extractArmadaServerConfig(config runtime.RawExtension) (ArmadaServerConfig, error) {
-	appConfig, err := builders.ConvertRawExtensionToYaml(config)
-	if err != nil {
-		return ArmadaServerConfig{}, err
-	}
-	var asConfig ArmadaServerConfig
-	err = yaml.Unmarshal([]byte(appConfig), &asConfig)
-	if err != nil {
-		return ArmadaServerConfig{}, err
-	}
-	return asConfig, err
 }

--- a/internal/controller/install/armadaserver_controller_test.go
+++ b/internal/controller/install/armadaserver_controller_test.go
@@ -433,7 +433,7 @@ func TestSchedulerReconciler_createIngress(t *testing.T) {
 
 	input := v1alpha1.ArmadaServer{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "armadaserver",
+			Kind:       "ArmadaServer",
 			APIVersion: "install.armadaproject.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/install/armadaserver_controller_test.go
+++ b/internal/controller/install/armadaserver_controller_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/armadaproject/armada-operator/internal/controller/builders"
 
 	"k8s.io/utils/ptr"
@@ -429,12 +433,12 @@ func TestSchedulerReconciler_createIngress(t *testing.T) {
 
 	input := v1alpha1.ArmadaServer{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Lookout",
+			Kind:       "armadaserver",
 			APIVersion: "install.armadaproject.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      "lookout",
+			Name:      "armadaserver",
 		},
 		Spec: v1alpha1.ArmadaServerSpec{
 			Replicas:      ptr.To[int32](2),
@@ -458,4 +462,211 @@ func TestSchedulerReconciler_createIngress(t *testing.T) {
 	// expect no error and not-nil ingress
 	assert.NoError(t, err)
 	assert.NotNil(t, ingress)
+}
+
+func TestArmadaServerReconciler_CreateDeployment(t *testing.T) {
+	t.Parallel()
+
+	commonConfig := &builders.CommonApplicationConfig{
+		HTTPPort:    8080,
+		GRPCPort:    5051,
+		MetricsPort: 9000,
+		Profiling: builders.ProfilingConfig{
+			Port: 1337,
+		},
+	}
+
+	armadaServer := &installv1alpha1.ArmadaServer{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ArmadaServer",
+			APIVersion: "install.armadaproject.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "armadaserver"},
+		Spec: installv1alpha1.ArmadaServerSpec{
+			PulsarInit: true,
+			CommonSpecBase: installv1alpha1.CommonSpecBase{
+				Labels: map[string]string{"test": "hello"},
+				Image: installv1alpha1.Image{
+					Repository: "testrepo",
+					Tag:        "1.0.0",
+				},
+				ApplicationConfig: runtime.RawExtension{},
+				Resources:         &corev1.ResourceRequirements{},
+				Prometheus:        &installv1alpha1.PrometheusConfig{Enabled: true},
+			},
+			ClusterIssuer: "test",
+			HostNames:     []string{"localhost"},
+			Ingress: &installv1alpha1.IngressConfig{
+				IngressClass: "nginx",
+				Labels:       map[string]string{"test": "hello"},
+				Annotations:  map[string]string{"test": "hello"},
+			},
+		},
+	}
+
+	deployment, err := createArmadaServerDeployment(armadaServer, "armadaserver", commonConfig)
+	assert.NoError(t, err)
+
+	expectedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "armadaserver",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":     "armadaserver",
+				"release": "armadaserver",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To[int32](1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "armadaserver",
+				},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &intstr.IntOrString{
+						IntVal: 1,
+					},
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "armadaserver",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":     "armadaserver",
+						"release": "armadaserver",
+					},
+					Annotations: map[string]string{
+						"checksum/config": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "app",
+													Operator: metav1.LabelSelectorOpIn,
+													Values: []string{
+														"armadaserver",
+													},
+												},
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "user-config",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "armadaserver",
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Args: []string{
+								"--config",
+								"/config/application_config.yaml",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SERVICE_ACCOUNT",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.serviceAccountName",
+										},
+									},
+								},
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+							Image:           "testrepo:1.0.0",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromString("http"),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      10,
+								FailureThreshold:    3,
+							},
+							Name: "armadaserver",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "grpc",
+									ContainerPort: 5051,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "http",
+									ContainerPort: 8080,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "metrics",
+									ContainerPort: 9000,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "profiling",
+									ContainerPort: 1337,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromString("http"),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
+								FailureThreshold:    2,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "user-config",
+									ReadOnly:  true,
+									MountPath: appConfigFilepath,
+									SubPath:   "armadaserver-config.yaml",
+								},
+							},
+						},
+					},
+					ServiceAccountName: "armadaserver",
+				},
+			},
+		},
+	}
+
+	if !cmp.Equal(expectedDeployment, deployment, protocmp.Transform()) {
+		t.Fatalf("deployment is not the same %s", cmp.Diff(expectedDeployment, deployment, protocmp.Transform()))
+	}
 }

--- a/internal/controller/install/binoculars_controller_test.go
+++ b/internal/controller/install/binoculars_controller_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/armadaproject/armada-operator/internal/controller/builders"
 
 	"k8s.io/utils/ptr"
@@ -14,6 +18,7 @@ import (
 	"github.com/armadaproject/armada-operator/test/k8sclient"
 
 	"github.com/golang/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -476,12 +481,12 @@ func TestSchedulerReconciler_createBinocularsIngress(t *testing.T) {
 
 	input := v1alpha1.Binoculars{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Lookout",
+			Kind:       "binoculars",
 			APIVersion: "install.armadaproject.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      "lookout",
+			Name:      "binoculars",
 		},
 		Spec: v1alpha1.BinocularsSpec{
 			Replicas:      ptr.To[int32](2),
@@ -505,4 +510,209 @@ func TestSchedulerReconciler_createBinocularsIngress(t *testing.T) {
 	// expect no error and not-nil ingress
 	assert.NoError(t, err)
 	assert.NotNil(t, ingress)
+}
+
+func TestBinocularsReconciler_CreateDeployment(t *testing.T) {
+	t.Parallel()
+
+	commonConfig := &builders.CommonApplicationConfig{
+		HTTPPort:    8080,
+		GRPCPort:    5051,
+		MetricsPort: 9000,
+		Profiling: builders.ProfilingConfig{
+			Port: 1337,
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "binoculars",
+		},
+	}
+
+	binoculars := &v1alpha1.Binoculars{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Binoculars",
+			APIVersion: "install.armadaproject.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "binoculars"},
+		Spec: v1alpha1.BinocularsSpec{
+			CommonSpecBase: installv1alpha1.CommonSpecBase{
+				Labels: map[string]string{"test": "hello"},
+				Image: installv1alpha1.Image{
+					Repository: "testrepo",
+					Tag:        "1.0.0",
+				},
+				ApplicationConfig: runtime.RawExtension{},
+				Resources:         &corev1.ResourceRequirements{},
+			},
+
+			Replicas:      ptr.To[int32](2),
+			HostNames:     []string{"localhost"},
+			ClusterIssuer: "test",
+			Ingress: &installv1alpha1.IngressConfig{
+				IngressClass: "nginx",
+				Labels:       map[string]string{"test": "hello"},
+				Annotations:  map[string]string{"test": "hello"},
+			},
+		},
+	}
+
+	deployment, err := createBinocularsDeployment(binoculars, secret, "binoculars", commonConfig)
+	assert.NoError(t, err)
+
+	expectedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "binoculars",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":     "binoculars",
+				"release": "binoculars",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To[int32](2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "binoculars",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "binoculars",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":     "binoculars",
+						"release": "binoculars",
+					},
+					Annotations: map[string]string{
+						"checksum/config": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "app",
+													Operator: metav1.LabelSelectorOpIn,
+													Values: []string{
+														"binoculars",
+													},
+												},
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "user-config",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "binoculars",
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Args: []string{
+								"--config",
+								"/config/application_config.yaml",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SERVICE_ACCOUNT",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.serviceAccountName",
+										},
+									},
+								},
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+							Image:           "testrepo:1.0.0",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromString("http"),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      10,
+								FailureThreshold:    3,
+							},
+							Name: "binoculars",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "grpc",
+									ContainerPort: 5051,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "http",
+									ContainerPort: 8080,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "metrics",
+									ContainerPort: 9000,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "profiling",
+									ContainerPort: 1337,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromString("http"),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
+								FailureThreshold:    2,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "user-config",
+									ReadOnly:  true,
+									MountPath: appConfigFilepath,
+									SubPath:   "binoculars-config.yaml",
+								},
+							},
+						},
+					},
+					ServiceAccountName: "binoculars",
+				},
+			},
+		},
+	}
+
+	if !cmp.Equal(expectedDeployment, deployment, protocmp.Transform()) {
+		t.Fatalf("deployment is not the same %s", cmp.Diff(expectedDeployment, deployment, protocmp.Transform()))
+	}
 }

--- a/internal/controller/install/binoculars_controller_test.go
+++ b/internal/controller/install/binoculars_controller_test.go
@@ -481,7 +481,7 @@ func TestSchedulerReconciler_createBinocularsIngress(t *testing.T) {
 
 	input := v1alpha1.Binoculars{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "binoculars",
+			Kind:       "Binoculars",
 			APIVersion: "install.armadaproject.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/install/common_helpers.go
+++ b/internal/controller/install/common_helpers.go
@@ -229,14 +229,6 @@ type PulsarConfig struct {
 	Cacert                string
 }
 
-type GrpcConfig struct {
-	Tls TlsConfig
-}
-
-type TlsConfig struct {
-	Enabled bool
-}
-
 // ArmadaInit used to initialize pulsar
 type ArmadaInit struct {
 	Enabled    bool
@@ -329,7 +321,7 @@ func ExtractPulsarConfig(config runtime.RawExtension) (PulsarConfig, error) {
 }
 
 // GetServerScheme returns the URI scheme for the grpc server
-func GetServerScheme(tlsConfig TlsConfig) corev1.URIScheme {
+func GetServerScheme(tlsConfig builders.TLSConfig) corev1.URIScheme {
 	if tlsConfig.Enabled {
 		return corev1.URISchemeHTTPS
 	}

--- a/internal/controller/install/common_helpers.go
+++ b/internal/controller/install/common_helpers.go
@@ -317,7 +317,7 @@ func ExtractPulsarConfig(config runtime.RawExtension) (PulsarConfig, error) {
 	if err != nil {
 		return PulsarConfig{}, err
 	}
-	return asConfig.Pulsar, err
+	return asConfig.Pulsar, nil
 }
 
 // GetServerScheme returns the URI scheme for the grpc server

--- a/internal/controller/install/executor_controller.go
+++ b/internal/controller/install/executor_controller.go
@@ -180,7 +180,7 @@ func (r *ExecutorReconciler) generateExecutorInstallComponents(
 		}
 		serviceAccountName = serviceAccount.Name
 	}
-	deployment := r.createDeployment(executor, serviceAccountName, config)
+	deployment := createExecutorDeployment(executor, serviceAccountName, config)
 	if err = controllerutil.SetOwnerReference(executor, deployment, scheme); err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -241,7 +241,7 @@ func (r *ExecutorReconciler) generateExecutorInstallComponents(
 	return components, nil
 }
 
-func (r *ExecutorReconciler) createDeployment(
+func createExecutorDeployment(
 	executor *installv1alpha1.Executor,
 	serviceAccountName string,
 	config *builders.CommonApplicationConfig,
@@ -249,7 +249,6 @@ func (r *ExecutorReconciler) createDeployment(
 	var replicas int32 = 1
 	volumes := createVolumes(executor.Name, executor.Spec.AdditionalVolumes)
 	volumeMounts := createVolumeMounts(GetConfigFilename(executor.Name), executor.Spec.AdditionalVolumeMounts)
-
 	readinessProbe, livenessProbe := CreateProbesWithScheme(corev1.URISchemeHTTP)
 
 	env := []corev1.EnvVar{
@@ -276,7 +275,7 @@ func (r *ExecutorReconciler) createDeployment(
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Image:           ImageString(executor.Spec.Image),
 		Args:            []string{appConfigFlag, appConfigFilepath},
-		Ports:           newContainerPortsMetrics(config),
+		Ports:           newContainerPortsHTTPWithMetrics(config),
 		Env:             env,
 		VolumeMounts:    volumeMounts,
 		SecurityContext: executor.Spec.SecurityContext,

--- a/internal/controller/install/executor_controller.go
+++ b/internal/controller/install/executor_controller.go
@@ -250,6 +250,8 @@ func (r *ExecutorReconciler) createDeployment(
 	volumes := createVolumes(executor.Name, executor.Spec.AdditionalVolumes)
 	volumeMounts := createVolumeMounts(GetConfigFilename(executor.Name), executor.Spec.AdditionalVolumeMounts)
 
+	readinessProbe, livenessProbe := CreateProbesWithScheme(corev1.URISchemeHTTP)
+
 	env := []corev1.EnvVar{
 		{
 			Name: "SERVICE_ACCOUNT",
@@ -278,6 +280,8 @@ func (r *ExecutorReconciler) createDeployment(
 		Env:             env,
 		VolumeMounts:    volumeMounts,
 		SecurityContext: executor.Spec.SecurityContext,
+		ReadinessProbe:  readinessProbe,
+		LivenessProbe:   livenessProbe,
 	}}
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: executor.Name, Namespace: executor.Namespace, Labels: AllLabels(executor.Name, executor.Labels)},

--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -139,7 +139,6 @@ func (r *LookoutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 type LookoutConfig struct {
 	Postgres PostgresConfig
-	Tls      TlsConfig
 }
 
 func generateLookoutInstallComponents(
@@ -271,13 +270,7 @@ func createLookoutDeployment(lookout *installv1alpha1.Lookout, serviceAccountNam
 	env := createEnv(lookout.Spec.Environment)
 	volumes := createVolumes(lookout.Name, lookout.Spec.AdditionalVolumes)
 	volumeMounts := createVolumeMounts(GetConfigFilename(lookout.Name), lookout.Spec.AdditionalVolumeMounts)
-
-	lookoutConfig, err := extractLookoutConfig(lookout.Spec.ApplicationConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(lookoutConfig.Tls))
+	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(config.GRPC.TLS))
 
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: lookout.Name, Namespace: lookout.Namespace, Labels: AllLabels(lookout.Name, lookout.Labels)},

--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -139,6 +139,7 @@ func (r *LookoutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 type LookoutConfig struct {
 	Postgres PostgresConfig
+	Tls      TlsConfig
 }
 
 func generateLookoutInstallComponents(
@@ -271,6 +272,13 @@ func createLookoutDeployment(lookout *installv1alpha1.Lookout, serviceAccountNam
 	volumes := createVolumes(lookout.Name, lookout.Spec.AdditionalVolumes)
 	volumeMounts := createVolumeMounts(GetConfigFilename(lookout.Name), lookout.Spec.AdditionalVolumeMounts)
 
+	lookoutConfig, err := extractLookoutConfig(lookout.Spec.ApplicationConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(lookoutConfig.Tls))
+
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: lookout.Name, Namespace: lookout.Namespace, Labels: AllLabels(lookout.Name, lookout.Labels)},
 		Spec: appsv1.DeploymentSpec{
@@ -299,6 +307,8 @@ func createLookoutDeployment(lookout *installv1alpha1.Lookout, serviceAccountNam
 						Env:             env,
 						VolumeMounts:    volumeMounts,
 						SecurityContext: lookout.Spec.SecurityContext,
+						ReadinessProbe:  readinessProbe,
+						LivenessProbe:   livenessProbe,
 					}},
 					Volumes: volumes,
 				},
@@ -458,12 +468,7 @@ func createLookoutCronJob(lookout *installv1alpha1.Lookout, serviceAccountName s
 		dbPruningSchedule = *lookout.Spec.DbPruningSchedule
 	}
 
-	appConfig, err := builders.ConvertRawExtensionToYaml(lookout.Spec.ApplicationConfig)
-	if err != nil {
-		return nil, err
-	}
-	var lookoutConfig LookoutConfig
-	err = yaml.Unmarshal([]byte(appConfig), &lookoutConfig)
+	lookoutConfig, err := extractLookoutConfig(lookout.Spec.ApplicationConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -554,4 +559,18 @@ func (r *LookoutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&installv1alpha1.Lookout{}).
 		Complete(r)
+}
+
+// extractLookoutConfig will unmarshal the appconfig and return the LookoutConfig portion
+func extractLookoutConfig(config runtime.RawExtension) (LookoutConfig, error) {
+	appConfig, err := builders.ConvertRawExtensionToYaml(config)
+	if err != nil {
+		return LookoutConfig{}, err
+	}
+	var lookoutConfig LookoutConfig
+	err = yaml.Unmarshal([]byte(appConfig), &lookoutConfig)
+	if err != nil {
+		return LookoutConfig{}, err
+	}
+	return lookoutConfig, err
 }

--- a/internal/controller/install/lookout_controller_test.go
+++ b/internal/controller/install/lookout_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -345,6 +347,201 @@ func TestLookoutReconciler_CreateCronJobErrorDueToApplicationConfig(t *testing.T
 	_, err := createLookoutCronJob(&expectedLookout, "lookout")
 	assert.Error(t, err)
 	assert.Equal(t, "yaml: line 1: did not find expected ',' or '}'", err.Error())
+}
+
+func TestLookoutReconciler_CreateDeployment(t *testing.T) {
+	t.Parallel()
+
+	commonConfig := &builders.CommonApplicationConfig{
+		HTTPPort:    8080,
+		GRPCPort:    5051,
+		MetricsPort: 9000,
+		Profiling: builders.ProfilingConfig{
+			Port: 1337,
+		},
+	}
+
+	lookout := &v1alpha1.Lookout{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Lookout",
+			APIVersion: "install.armadaproject.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "lookout",
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:        []string{operatorFinalizer},
+		},
+		Spec: v1alpha1.LookoutSpec{
+			CommonSpecBase: installv1alpha1.CommonSpecBase{
+				Labels: nil,
+				Image: v1alpha1.Image{
+					Repository: "testrepo",
+					Tag:        "1.0.0",
+				},
+				ApplicationConfig: runtime.RawExtension{Raw: []byte(`{}`)},
+				Resources:         &corev1.ResourceRequirements{},
+			},
+			Replicas:      ptr.To[int32](2),
+			ClusterIssuer: "test",
+			Ingress: &v1alpha1.IngressConfig{
+				IngressClass: "nginx",
+			},
+		},
+	}
+
+	deployment, err := createLookoutDeployment(lookout, "lookout", commonConfig)
+	assert.NoError(t, err)
+
+	expectedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lookout",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":     "lookout",
+				"release": "lookout",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To[int32](2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "lookout",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lookout",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":     "lookout",
+						"release": "lookout",
+					},
+					Annotations: map[string]string{
+						"checksum/config": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "app",
+													Operator: metav1.LabelSelectorOpIn,
+													Values: []string{
+														"lookout",
+													},
+												},
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "user-config",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "lookout",
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Args: []string{
+								"--config",
+								"/config/application_config.yaml",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "SERVICE_ACCOUNT",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.serviceAccountName",
+										},
+									},
+								},
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+							Image:           "testrepo:1.0.0",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromString("http"),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      10,
+								FailureThreshold:    3,
+							},
+							Name: "lookout",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: 8080,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "metrics",
+									ContainerPort: 9000,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "profiling",
+									ContainerPort: 1337,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromString("http"),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
+								FailureThreshold:    2,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "user-config",
+									ReadOnly:  true,
+									MountPath: appConfigFilepath,
+									SubPath:   "lookout-config.yaml",
+								},
+							},
+						},
+					},
+					ServiceAccountName: "lookout",
+				},
+			},
+		},
+	}
+
+	if !cmp.Equal(expectedDeployment, deployment, protocmp.Transform()) {
+		t.Fatalf("deployment is not the same %s", cmp.Diff(expectedDeployment, deployment, protocmp.Transform()))
+	}
 }
 
 func TestLookoutReconciler_CreateCronJob(t *testing.T) {

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -141,7 +141,6 @@ func (r *SchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 type SchedulerConfig struct {
-	Grpc     GrpcConfig
 	Postgres PostgresConfig
 }
 
@@ -290,12 +289,7 @@ func newSchedulerDeployment(
 	volumes = append(volumes, createPulsarVolumes(pulsarConfig)...)
 	volumeMounts := createVolumeMounts(GetConfigFilename(scheduler.Name), scheduler.Spec.AdditionalVolumeMounts)
 	volumeMounts = append(volumeMounts, createPulsarVolumeMounts(pulsarConfig)...)
-
-	schedulerConfig, err := extractSchedulerConfig(scheduler.Spec.ApplicationConfig)
-	if err != nil {
-		return nil, err
-	}
-	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(schedulerConfig.Grpc.Tls))
+	readinessProbe, livenessProbe := CreateProbesWithScheme(GetServerScheme(config.GRPC.TLS))
 
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: scheduler.Name, Namespace: scheduler.Namespace, Labels: AllLabels(scheduler.Name, scheduler.Labels)},


### PR DESCRIPTION
## Description

The pull request updates various controllers to add readiness & liveness probes to containers where applicable. These probes should help indicate when it is safe to cutover to new deployments. 

I cross referenced https://github.com/armadaproject/armada/tree/master/deployment (I may have found some bugs in here tho) as well as each application's config structs to understand which ports they expose. 

Fixes #334 

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?
Added unit tests to assert the fully generated deployment with probes. 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
