### PR TITLE
fix: Set armada server replicas from spec

### DIFF
--- a/internal/controller/install/armadaserver_controller.go
+++ b/internal/controller/install/armadaserver_controller.go
@@ -438,7 +438,6 @@ func createArmadaServerDeployment(
 	serviceAccountName string,
 	commonConfig *builders.CommonApplicationConfig,
 ) (*appsv1.Deployment, error) {
-	var replicas int32 = 1
 	env := createEnv(as.Spec.Environment)
 	pulsarConfig, err := ExtractPulsarConfig(as.Spec.ApplicationConfig)
 	if err != nil {
@@ -458,7 +457,7 @@ func createArmadaServerDeployment(
 			Labels:    AllLabels(as.Name, as.Labels),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
+			Replicas: as.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: IdentityLabel(as.Name),
 			},

--- a/internal/controller/install/armadaserver_controller_test.go
+++ b/internal/controller/install/armadaserver_controller_test.go
@@ -501,6 +501,7 @@ func TestArmadaServerReconciler_CreateDeployment(t *testing.T) {
 				Labels:       map[string]string{"test": "hello"},
 				Annotations:  map[string]string{"test": "hello"},
 			},
+			Replicas: ptr.To[int32](2),
 		},
 	}
 
@@ -517,7 +518,7 @@ func TestArmadaServerReconciler_CreateDeployment(t *testing.T) {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: ptr.To[int32](1),
+			Replicas: ptr.To[int32](2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "armadaserver",


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request allows users to run Armada Server in an HA manner so that it will be available during rolling upgrades.

Fixes #341 

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?
Unit Tests & Our Environment

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
