### PR TITLE
ci: Reduce permissions of semantic-pull-request check

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
## Description

- **What is the purpose of this PR?**

Reduce permissions of the lint-pr github action.

- **What was changed?**

Add a permissions block to lint-pr. This is now the recommended option in:
https://github.com/amannn/action-semantic-pull-request#installation

- **Why was it changed?**

Recently a project has been attacked using `pull_request_target` see [full details](https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection). This project/action is not vulnerable to that, but there is no reason for the token associated with this action to have write permissions.

- **Does this address any existing issues or enhancement requests?**

n/a, improves security posture of the project.

## Type of change

Please select the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [x] Other (please describe): CI Security

## How Has This Been Tested?

Only affects CI; CI will test it.

Can check by looking at "Set up job" and then expanding "GITHUB_TOKEN Permissions" on the "Validate PR title" PR check. Before it will say "write", after it should only have "read". (Note because this is using `pull_request_target` this won't be visible on this PR, only once merged to main).