### PR TITLE
fix: Pruning cron jobs should forbid concurrency

### DIFF
--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -479,7 +479,8 @@ func createLookoutCronJob(lookout *installv1alpha1.Lookout, serviceAccountName s
 			Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(lookout.Spec.ApplicationConfig.Raw)},
 		},
 		Spec: batchv1.CronJobSpec{
-			Schedule: dbPruningSchedule,
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+			Schedule:          dbPruningSchedule,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/internal/controller/install/lookout_controller_test.go
+++ b/internal/controller/install/lookout_controller_test.go
@@ -783,6 +783,7 @@ func TestLookoutReconciler_CreateCronJob(t *testing.T) {
 			},
 		},
 		Spec: batchv1.CronJobSpec{
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "lookout-db-pruner",

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -520,7 +520,8 @@ func newSchedulerCronJob(scheduler *installv1alpha1.Scheduler, serviceAccountNam
 			Annotations: map[string]string{"checksum/config": GenerateChecksumConfig(scheduler.Spec.ApplicationConfig.Raw)},
 		},
 		Spec: batchv1.CronJobSpec{
-			Schedule: scheduler.Spec.Pruner.Schedule,
+			Schedule:          scheduler.Spec.Pruner.Schedule,
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/internal/controller/install/scheduler_controller_test.go
+++ b/internal/controller/install/scheduler_controller_test.go
@@ -969,6 +969,7 @@ func TestSchedulerReconciler_createSchedulerCronJob(t *testing.T) {
 			},
 		},
 		Spec: batchv1.CronJobSpec{
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
 			JobTemplate: batchv1.JobTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "scheduler-db-pruner",


### PR DESCRIPTION
# Pull Request Template

## Description

If pruning cron jobs have misconfigured timeouts/schedules they have an opportunity to run concurrently. We should forbid that.

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?

Unit tests

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
