### PR TITLE
ci: Make required checks job pass only on success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
   # Virtual job that can be configured as a required check before a PR can be merged.
   all-required-checks-done:
     name: All required checks done
-    if: ${{ always() }}
     needs:
       - lint
       - test


### PR DESCRIPTION
## Description

Currently, the `all-required-checks-done` job runs and succeeds `always()`, even if jobs it depends on fail, are cancelled or skipped. It succeeds even if other jobs don't. Usually, you want to block pull request merges until CI pipeline succeeds, not until it just finishes.

## Type of change
CI

## How Has This Been Tested?
Failed workflow before this change:
https://github.com/EnricoMi/armada-operator/actions/runs/13922761708/job/38961096882

Skipped workflow before this change:
https://github.com/EnricoMi/armada-operator/actions/runs/13924158519/job/38964210807

Cancelled workflow after this change:
https://github.com/EnricoMi/armada-operator/actions/runs/13924283498/job/38964942928

Successful run after this change:
https://github.com/EnricoMi/armada-operator/actions/runs/13924283498

## Checklist:
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.