### PR TITLE
fix: Use minimal pulsar values

### DIFF
--- a/dev/quickstart/pulsar.values.yaml
+++ b/dev/quickstart/pulsar.values.yaml
@@ -9,14 +9,48 @@ kube-prometheus-stack:
   alertmanager:
     enabled: false
 
+
+# minimal pulsar broker config inspired by
+# https://github.com/apache/pulsar-helm-chart/blob/master/examples/values-minikube.yaml
+
+# deployed withh emptyDir
+volumes:
+  persistence: false
+
+# disabled AntiAffinity
+affinity:
+  anti_affinity: false
+
+# disable auto recovery
+components:
+  autorecovery: false
+  pulsar_manager: true
+
 broker:
   replicaCount: 1
+  configData:
+    ## Enable `autoSkipNonRecoverableData` since bookkeeper is running
+    ## without persistence
+    autoSkipNonRecoverableData: "true"
+    # storage settings
+    managedLedgerDefaultEnsembleSize: "1"
+    managedLedgerDefaultWriteQuorum: "1"
+    managedLedgerDefaultAckQuorum: "1"
 
 zookeeper:
   replicaCount: 1
 
 bookkeeper:
   replicaCount: 1
+  configData:
+    # minimal memory use for bookkeeper
+    # https://bookkeeper.apache.org/docs/reference/config#db-ledger-storage-settings
+    dbStorage_writeCacheMaxSizeMb: "32"
+    dbStorage_readAheadCacheMaxSizeMb: "32"
+    dbStorage_rocksDB_writeBufferSizeMB: "8"
+    dbStorage_rocksDB_blockCacheSize: "8388608"
+    # make bookie work with large disks having little percentage disk space left
+    diskUsageThreshold: "0.999"
 
 proxy:
   replicaCount: 1

--- a/hack/wait-for-deps.sh
+++ b/hack/wait-for-deps.sh
@@ -5,7 +5,6 @@ STATEFULSETS=(
     "pulsar-bookie"
     "pulsar-broker"
     "pulsar-proxy"
-    "pulsar-recovery"
     "pulsar-toolset"
     "pulsar-zookeeper"
     "redis-ha-server"


### PR DESCRIPTION
# Pull Request Template

## Description

This amends `armada-operator/dev/quickstart/pulsar.values.yaml` with some minimal setup values suggested by [Pulsar helm chart examples for minikube](https://github.com/apache/pulsar-helm-chart/blob/master/examples/values-minikube.yaml).

Specifically `diskUsageThreshold: "0.999"` (not taken from minikube example) fixes issues we see with bookie complaining about too little free disk. On Github runners, 5% of 72G is plenty of free disk for our example.

## Type of change

Please select the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [X] Other (please describe): Improvement (not really a bug fix, nor a feature)

## How Has This Been Tested?

This operator is used in the end-to-end test of Armada-Spark: https://github.com/armadaproject/armada-spark/pull/31

Before this fix, we see

      2025-04-11T17:07:35,565+0000 [LedgerDirsMonitorThread] ERROR org.apache.bookkeeper.util.DiskChecker - Space left on device /pulsar/data/bookkeeper/ledgers/current : 3557601280, Used space fraction: 0.95372957 > threshold 0.95.

Because pulsar bookie claims 3.5 GB (5%) of free disk is not enough. Now, the threshold is at 0.1%.

Now, it only warns:

      2025-04-14T14:49:53,367+0000 [LedgerDirsMonitorThread] WARN  org.apache.bookkeeper.util.DiskChecker - Space left on device /pulsar/data/bookkeeper/ledgers/current : 2826395648, Used space fraction: 0.96323967 > WarnThreshold 0.9.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.