### PR TITLE
fix: Allow setting the name for priorityClass

### DIFF
--- a/charts/armada-operator/crds/executor-crd.yaml
+++ b/charts/armada-operator/crds/executor-crd.yaml
@@ -2339,6 +2339,9 @@ spec:
                         Standard object's metadata.
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                       type: object
+                      properties:
+                        name:
+                          type: string
                     preemptionPolicy:
                       description: |-
                         preemptionPolicy is the Policy for preempting pods with lower priority.


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the changes and the related issue (if any). Describe your changes in detail to help reviewers understand your contribution.

- **What is the purpose of this PR?**

The CRD should allow setting the priorityClass object name according to docs

- **What was changed?**

The name field added to the CRD priorityClass metadata object

- **Why was it changed?**

Because the priorityObject needs a name

- **Does this address any existing issues or enhancement requests?**

No

Fixes # (issue)

## Type of change

Please select the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code Style Update (formatting, renaming)
- [ ] Refactor (code changes that do not fix a bug or add a feature)
- [ ] Documentation Update
- [ ] Other (please describe):

## How Has This Been Tested?

The CRD allows setting the name after the change

- **Test Configuration**:
    - Kubernetes Version:
    - Helm Version:
    - OS:

- **Test Steps**:
    1. Step 1
    2. Step 2
    3. ...

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
