### PR TITLE
test: add an e2e that submits a job to Armada on kind

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,42 @@
+name: E2E
+
+on:
+  pull_request:
+    branches-ignore:
+      - gh-pages
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: End-to-end (kind)
+    runs-on: ubuntu-latest
+    # Skip on fork PRs from a different repo (same guard style as ci.yml jobs).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-cache
+        with:
+          go-version: "1.24"
+          cache-prefix: go-e2e
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+
+      - name: Run e2e
+        run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,10 @@ kind-all: kind-create-cluster install-and-wait-cert-manager helm-repos helm-inst
 .PHONY: kind-all-dev
 kind-all-dev: kind-create-cluster kind-deploy helm-repos install-armada-deps wait-for-armada-deps create-armada-namespace apply-armada-crs create-armadactl-config apply-default-priority-class get-armadactl wait-for-armada ## Install everything with Operator built from scratch
 
+.PHONY: test-e2e
+test-e2e: ## Run the end-to-end test (kind-all-dev + create queue + submit job + wait for success). Set E2E_KEEP_CLUSTER=true to keep the cluster.
+	scripts/e2e-test.sh
+
 .PHONY: kind-create-cluster
 kind-create-cluster: kind ## Create a kind cluster using config from hack/kind-config.yaml.
 	$(KIND) create cluster --config hack/kind-config.yaml --name $(KIND_CLUSTER_NAME)

--- a/dev/quickstart/armada-crs.yaml
+++ b/dev/quickstart/armada-crs.yaml
@@ -72,6 +72,10 @@ spec:
       forceNoTls: true
     metric:
       port: 9001
+    # Request work and report spare cluster capacity to the scheduler frequently,
+    # so a freshly started cluster becomes schedulable within seconds (default is 5s).
+    task:
+      allocateSpareClusterCapacityInterval: 2s
 ---
 apiVersion: install.armadaproject.io/v1alpha1
 kind: Lookout
@@ -139,6 +143,12 @@ spec:
     repository: gresearch/armada-scheduler
     tag: latest
   applicationConfig:
+    # Ingest executor-reported capacity and run scheduling rounds frequently,
+    # so submitted jobs are picked up within a few seconds.
+    # Defaults are 60s / 10s; lowered here for this quickstart/dev setup.
+    schedulePeriod: 5s
+    scheduling:
+      executorUpdateFrequency: 5s
     grpc:
       port: 50051
     auth:

--- a/dev/quickstart/example-job.yaml
+++ b/dev/quickstart/example-job.yaml
@@ -8,17 +8,17 @@ jobs:
       terminationGracePeriodSeconds: 0
       restartPolicy: Never
       containers:
-        - name: sleeper
+        - name: hello
           image: alpine:latest
           command:
             - sh
           args:
             - -c
-            - sleep $(( (RANDOM % 60) + 10 ))
+            - echo "Hello Armada"
           resources:
             limits:
-              memory: 128Mi
-              cpu: 2
+              memory: 64Mi
+              cpu: 100m
             requests:
-              memory: 128Mi
-              cpu: 2
+              memory: 64Mi
+              cpu: 100m

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,34 +1,156 @@
 #!/bin/bash
-
-set -eo pipefail
+#
+# End-to-end test for the Armada Operator.
+#
+# Builds the operator from source and brings up a full Armada install on a kind cluster
+# via the operator (make kind-all-dev), then creates a queue, submits a job,
+# and waits for that job to succeed.
+# All of the logic lives in this script so it runs the same way locally and in CI;
+# CI just calls `scripts/e2e-test.sh`.
+#
+# Usage:
+#   scripts/e2e-test.sh                          # full run, deletes the cluster at the end
+#   E2E_KEEP_CLUSTER=true scripts/e2e-test.sh    # keep the kind cluster for debugging
+#   E2E_TIMEOUT=900 scripts/e2e-test.sh          # override job-wait timeout (seconds)
+#
+# Environment overrides:
+#   E2E_QUEUE         queue name to create/submit to     (default: example)
+#   E2E_JOBSET        job set id to watch                 (default: job-set-1)
+#   E2E_TIMEOUT       seconds to wait for job success     (default: 600)
+#   E2E_KEEP_CLUSTER  "true" to skip cluster teardown     (default: false)
+#
+set -euo pipefail
 
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 NC='\033[0m'
+log() { echo -e "${GREEN}$1${NC}"; }
+err() { echo -e "${RED}$1${NC}" >&2; }
 
-log() {
-    echo -e "${GREEN}$1${NC}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# `make get-armadactl` installs armadactl into bin/app; put it on PATH.
+export PATH="$ROOT/bin/app:$PATH"
+
+QUEUE="${E2E_QUEUE:-example}"
+JOBSET="${E2E_JOBSET:-job-set-1}"
+TIMEOUT="${E2E_TIMEOUT:-600}"
+KEEP_CLUSTER="${E2E_KEEP_CLUSTER:-false}"
+
+# retry_until <timeout_secs> <description> <cmd...>
+# Runs cmd until it exits 0 or the timeout elapses, polling every 5s.
+# If cmd's stderr reports the resource "already exists", that is treated as success.
+# Each retry prints the elapsed time, and every ~30s it also prints a snapshot of the
+# armada pods, so a stalled wait can be diagnosed straight from the log.
+retry_until() {
+  local timeout="$1" desc="$2"
+  shift 2
+  local err_file start now last_snap
+  err_file="$(mktemp)"
+  start=$(date +%s)
+  last_snap=$start
+  until "$@" 2>"${err_file}"; do
+    cat "${err_file}" >&2
+    if grep -qiE "already exists" "${err_file}"; then
+      log "${desc}: already exists, continuing"
+      break
+    fi
+    now=$(date +%s)
+    if [ "$(( now - start ))" -ge "${timeout}" ]; then
+      err "${desc}: did not succeed within ${timeout}s."
+      rm -f "${err_file}"
+      return 1
+    fi
+    if [ "$(( now - last_snap ))" -ge 30 ]; then
+      last_snap=$now
+      log "${desc}: still waiting ($(( now - start ))s/${timeout}s); armada pods:"
+      kubectl get pods -n armada --no-headers 2>/dev/null \
+        | awk '{printf "    %-58s %-7s %s\n", $1, $2, $3}' || true
+    else
+      log "${desc}: not ready yet ($(( now - start ))s/${timeout}s), retrying in 5s..."
+    fi
+    sleep 5
+  done
+  rm -f "${err_file}"
 }
 
-log "Running e2e tests..."
+dump_diagnostics() {
+  err "==================== E2E FAILED: diagnostics ===================="
+  kubectl get pods -A || true
+  kubectl get armadaservers,executors,schedulers,lookouts,eventingesters -A || true
+  kubectl -n armada describe pods || true
+  kubectl -n armada logs -l app=armada-server --tail=200 --all-containers || true
+  kubectl -n armada logs -l app=armada-scheduler --tail=200 --all-containers || true
+  kubectl -n armada logs -l app=armada-executor --tail=200 --all-containers || true
+  kubectl -n armada-system logs deployment/armada-operator-controller-manager \
+    -c manager --tail=200 || true
+  kubectl get events -A --sort-by=.lastTimestamp | tail -100 || true
+  err "================================================================"
+}
 
-log "Creating kind cluster..."
-make kind-create-cluster
+cleanup() {
+  rc=$?
+  rm -f "${events:-}"
+  if [ "$rc" -ne 0 ]; then
+    dump_diagnostics
+  fi
+  if [ "$KEEP_CLUSTER" = "true" ]; then
+    log "E2E_KEEP_CLUSTER=true -- leaving the kind cluster running."
+  else
+    log "Deleting kind cluster..."
+    make kind-delete-cluster || true
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
 
-log "Installing cert-manager..."
-make install-and-wait-cert-manager
+log "==> Building the operator from source and bringing up Armada on kind (make kind-all-dev)..."
+make kind-all-dev
 
-log "Building latest version of the operator and installing it via Helm..."
-make helm-install-local
+# `make wait-for-armada` only waits for the armada-server pod to be Ready,
+# but the `queue` table is created by the scheduler database migration,
+# which can finish a little later.
+# Retry until the API actually accepts queue creation before submitting.
+log "==> Waiting for Armada to accept queue operations and creating queue '${QUEUE}'..."
+retry_until 300 "create queue '${QUEUE}'" armadactl create queue "${QUEUE}"
 
-for i in {1..5}; do
-    kubectl get pods -n armada-system
-    kubectl describe deployment armada-operator-controller-manager -n armada-system
-    sleep 15
-    kubectl logs deployment/armada-operator-controller-manager -n armada-system
-done
+# A job submitted before the scheduler has the executor's nodes is Rejected
+# (JobFailedEvent cause=4, Cause_Rejected).
+# Each scheduling cycle the scheduler logs the capacity of every pool it knows about,
+# so wait until pool "default" has non-zero CPU (the executor's nodes are registered).
+# After that a submit is accepted and scheduled, which keeps this deterministic
+# and avoids a submit/reject retry loop.
+# This also subsumes waiting for the executor pod: the scheduler only reports capacity
+# once the executor is up and has registered.
+log "==> Waiting for the scheduler to register the executor's capacity..."
+scheduler_has_capacity() {
+  kubectl logs -n armada -l app=armada-scheduler --tail=200 2>/dev/null \
+    | grep -qE "Scheduling on pool .* with capacity \(memory=[0-9]+,cpu=[1-9]"
+}
+retry_until 600 "scheduler has executor capacity" scheduler_has_capacity
 
-log "Waiting for Armada Operator pod to be ready..."
-kubectl wait --for='condition=Ready' pods -l 'app.kubernetes.io/name=armada-operator' --timeout=600s --namespace armada-system
+# CreateQueue persists to Postgres,
+# but the submit API serves from a queue cache that refreshes on an interval,
+# so retry submit until the queue becomes visible.
+log "==> Submitting hello-world job to job set '${JOBSET}'..."
+retry_until 120 "submit job to queue '${QUEUE}'" armadactl submit dev/quickstart/example-job.yaml
 
-log "Deleting kind cluster..."
-make kind-delete-cluster
+# The set holds a single job,
+# so `watch --exit-if-inactive` returns as soon as that job is terminal.
+# watch exits 0 even on failure, so inspect the raw event stream ourselves.
+log "==> Waiting up to ${TIMEOUT}s for the job to finish..."
+events="$(mktemp)"
+timeout "${TIMEOUT}" armadactl watch --raw --exit-if-inactive "${QUEUE}" "${JOBSET}" | tee "${events}" || true
+
+if grep -q 'JobSucceededEvent' "${events}"; then
+  log "==> E2E PASSED: job in job set '${JOBSET}' succeeded."
+  exit 0
+fi
+failed="$(grep 'JobFailedEvent' "${events}" | tail -1 || true)"
+if [ -n "${failed}" ]; then
+  err "Job in job set '${JOBSET}' failed: ${failed}"
+  exit 1
+fi
+err "Job in job set '${JOBSET}' did not reach a terminal state within ${TIMEOUT}s."
+exit 1


### PR DESCRIPTION
Adds an end-to-end test that builds the operator from source, stands up Armada on a kind cluster through the operator, then creates a queue, submits a job, and waits for it to finish.

The logic lives in `scripts/e2e-test.sh` so it runs the same way locally (`make test-e2e`) and in CI. The new `.github/workflows/e2e.yml` just calls the script.

The example job is now a hello-world (`echo`) rather than a random sleep, so it finishes quickly. The quickstart CRs also lower the scheduler and executor reporting intervals so a fresh cluster becomes schedulable in a few seconds.

Instead of fixed sleeps, the script waits for the things it actually needs: the queue table to be migrated, the queue to be visible to the submit API, and the scheduler to report the executor's capacity. Once those hold it submits one job and watches it to a terminal state.