### PR TITLE
feat: add CRD field to set the postgres image in migration jobs

### DIFF
--- a/api/install/v1alpha1/lookout_types.go
+++ b/api/install/v1alpha1/lookout_types.go
@@ -61,6 +61,11 @@ type LookoutSpec struct {
 	ClusterIssuer string `json:"clusterIssuer,omitempty"`
 	// Migrate toggles whether to run migrations when installed
 	Migrate *bool `json:"migrate,omitempty"`
+	// MigrationDbWaitImage sets the image for the init container of the migration job.
+	// The init container waits for the database and creates the database.
+	// The image must contain the psql client and the nc command.
+	// The default value is postgres:15.2-alpine.
+	MigrationDbWaitImage *Image `json:"migrationDbWaitImage,omitempty"`
 	// DbPruningEnabled when true a pruning CronJob is created
 	DbPruningEnabled *bool `json:"dbPruningEnabled,omitempty"`
 	// DbPruningSchedule schedule to use for db pruning CronJob

--- a/api/install/v1alpha1/scheduler_types.go
+++ b/api/install/v1alpha1/scheduler_types.go
@@ -61,6 +61,11 @@ type SchedulerSpec struct {
 	ClusterIssuer string `json:"clusterIssuer,omitempty"`
 	// Migrate toggles whether to run migrations when installed
 	Migrate *bool `json:"migrate,omitempty"`
+	// MigrationDbWaitImage sets the image for the init container of the migration job.
+	// The init container waits for the database and creates the database.
+	// The image must contain the psql client and the nc command.
+	// The default value is postgres:15.2-alpine.
+	MigrationDbWaitImage *Image `json:"migrationDbWaitImage,omitempty"`
 	// Pruning config for cron job
 	Pruner *PrunerConfig `json:"pruner,omitempty"`
 	// SecurityContext defines the security options the container should be run with

--- a/api/install/v1alpha1/zz_generated.deepcopy.go
+++ b/api/install/v1alpha1/zz_generated.deepcopy.go
@@ -1012,6 +1012,11 @@ func (in *LookoutSpec) DeepCopyInto(out *LookoutSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MigrationDbWaitImage != nil {
+		in, out := &in.MigrationDbWaitImage, &out.MigrationDbWaitImage
+		*out = new(Image)
+		**out = **in
+	}
 	if in.DbPruningEnabled != nil {
 		in, out := &in.DbPruningEnabled, &out.DbPruningEnabled
 		*out = new(bool)
@@ -1368,6 +1373,11 @@ func (in *SchedulerSpec) DeepCopyInto(out *SchedulerSpec) {
 	if in.Migrate != nil {
 		in, out := &in.Migrate, &out.Migrate
 		*out = new(bool)
+		**out = **in
+	}
+	if in.MigrationDbWaitImage != nil {
+		in, out := &in.MigrationDbWaitImage, &out.MigrationDbWaitImage
+		*out = new(Image)
 		**out = **in
 	}
 	if in.Pruner != nil {

--- a/charts/armada-operator/crds/lookout-crd.yaml
+++ b/charts/armada-operator/crds/lookout-crd.yaml
@@ -2092,6 +2092,25 @@ spec:
               migrate:
                 description: Migrate toggles whether to run migrations when installed
                 type: boolean
+              migrationDbWaitImage:
+                description: |-
+                  MigrationDbWaitImage sets the image for the init container of the migration job.
+                  The init container waits for the database and creates the database.
+                  The image must contain the psql client and the nc command.
+                  The default value is postgres:15.2-alpine.
+                properties:
+                  repository:
+                    minLength: 1
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*/*)+$
+                    type: string
+                  tag:
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9_.-]*$
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/charts/armada-operator/crds/scheduler-crd.yaml
+++ b/charts/armada-operator/crds/scheduler-crd.yaml
@@ -2086,6 +2086,25 @@ spec:
               migrate:
                 description: Migrate toggles whether to run migrations when installed
                 type: boolean
+              migrationDbWaitImage:
+                description: |-
+                  MigrationDbWaitImage sets the image for the init container of the migration job.
+                  The init container waits for the database and creates the database.
+                  The image must contain the psql client and the nc command.
+                  The default value is postgres:15.2-alpine.
+                properties:
+                  repository:
+                    minLength: 1
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*/*)+$
+                    type: string
+                  tag:
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9_.-]*$
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/install.armadaproject.io_lookouts.yaml
+++ b/config/crd/bases/install.armadaproject.io_lookouts.yaml
@@ -2082,6 +2082,25 @@ spec:
               migrate:
                 description: Migrate toggles whether to run migrations when installed
                 type: boolean
+              migrationDbWaitImage:
+                description: |-
+                  MigrationDbWaitImage sets the image for the init container of the migration job.
+                  The init container waits for the database and creates the database.
+                  The image must contain the psql client and the nc command.
+                  The default value is postgres:15.2-alpine.
+                properties:
+                  repository:
+                    minLength: 1
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*/*)+$
+                    type: string
+                  tag:
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9_.-]*$
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/install.armadaproject.io_schedulers.yaml
+++ b/config/crd/bases/install.armadaproject.io_schedulers.yaml
@@ -2076,6 +2076,25 @@ spec:
               migrate:
                 description: Migrate toggles whether to run migrations when installed
                 type: boolean
+              migrationDbWaitImage:
+                description: |-
+                  MigrationDbWaitImage sets the image for the init container of the migration job.
+                  The init container waits for the database and creates the database.
+                  The image must contain the psql client and the nc command.
+                  The default value is postgres:15.2-alpine.
+                properties:
+                  repository:
+                    minLength: 1
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*/*)+$
+                    type: string
+                  tag:
+                    minLength: 1
+                    pattern: ^[a-zA-Z0-9_.-]*$
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/dev/crd/out.md
+++ b/dev/crd/out.md
@@ -502,6 +502,8 @@ _Appears in:_
 
 _Appears in:_
 - [CommonSpecBase](#commonspecbase)
+- [LookoutSpec](#lookoutspec)
+- [SchedulerSpec](#schedulerspec)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -679,6 +681,7 @@ _Appears in:_
 | `hostNames` _string array_ | An array of host names to build ingress rules for |  |  |
 | `clusterIssuer` _string_ | Who is issuing certificates for CA |  |  |
 | `migrate` _boolean_ | Migrate toggles whether to run migrations when installed |  |  |
+| `migrationDbWaitImage` _[Image](#image)_ | MigrationDbWaitImage sets the image for the init container of the migration job.<br />The init container waits for the database and creates the database.<br />The image must contain the psql client and the nc command.<br />The default value is postgres:15.2-alpine. |  |  |
 | `dbPruningEnabled` _boolean_ | DbPruningEnabled when true a pruning CronJob is created |  |  |
 | `dbPruningSchedule` _string_ | DbPruningSchedule schedule to use for db pruning CronJob |  |  |
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#securitycontext-v1-core)_ | SecurityContext defines the security options the container should be run with |  |  |
@@ -897,6 +900,7 @@ _Appears in:_
 | `hostNames` _string array_ | An array of host names to build ingress rules for |  |  |
 | `clusterIssuer` _string_ | Who is issuing certificates for CA |  |  |
 | `migrate` _boolean_ | Migrate toggles whether to run migrations when installed |  |  |
+| `migrationDbWaitImage` _[Image](#image)_ | MigrationDbWaitImage sets the image for the init container of the migration job.<br />The init container waits for the database and creates the database.<br />The image must contain the psql client and the nc command.<br />The default value is postgres:15.2-alpine. |  |  |
 | `pruner` _[PrunerConfig](#prunerconfig)_ | Pruning config for cron job |  |  |
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#securitycontext-v1-core)_ | SecurityContext defines the security options the container should be run with |  |  |
 | `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#podsecuritycontext-v1-core)_ | PodSecurityContext defines the security options the pod should be run with |  |  |

--- a/internal/controller/install/common_helpers.go
+++ b/internal/controller/install/common_helpers.go
@@ -856,3 +856,12 @@ func defaultDeploymentStrategy(maxUnavailable int32) appsv1.DeploymentStrategy {
 func defaultAlpineImage() string {
 	return "alpine:3.20"
 }
+
+// migrationDbWaitImageString returns the image for the init container of a migration job.
+// The init container needs the psql client and the nc command, so the default image is a postgres image.
+func migrationDbWaitImageString(image *installv1alpha1.Image) string {
+	if image != nil {
+		return ImageString(*image)
+	}
+	return "postgres:15.2-alpine"
+}

--- a/internal/controller/install/lookout_controller.go
+++ b/internal/controller/install/lookout_controller.go
@@ -386,7 +386,7 @@ func createLookoutMigrationJob(lookout *installv1alpha1.Lookout, serviceAccountN
 					SecurityContext:               lookout.Spec.PodSecurityContext,
 					InitContainers: []corev1.Container{{
 						Name:  "lookout-migration-db-wait",
-						Image: "postgres:15.2-alpine",
+						Image: migrationDbWaitImageString(lookout.Spec.MigrationDbWaitImage),
 						Command: []string{
 							"/bin/sh",
 							"-c",

--- a/internal/controller/install/lookout_controller_test.go
+++ b/internal/controller/install/lookout_controller_test.go
@@ -1079,6 +1079,26 @@ func Test_createLookoutMigrationJob(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "The default image is used for the db-wait init container",
+			verifyJob: func(t *testing.T, job *batchv1.Job) {
+				assert.Equal(t, "postgres:15.2-alpine", job.Spec.Template.Spec.InitContainers[0].Image)
+			},
+			wantErr: false,
+		},
+		{
+			name: "MigrationDbWaitImage sets the image of the db-wait init container",
+			modifyInput: func(cr *v1alpha1.Lookout) {
+				cr.Spec.MigrationDbWaitImage = &v1alpha1.Image{
+					Repository: "my-mirror.example.com/postgres",
+					Tag:        "15.2-alpine",
+				}
+			},
+			verifyJob: func(t *testing.T, job *batchv1.Job) {
+				assert.Equal(t, "my-mirror.example.com/postgres:15.2-alpine", job.Spec.Template.Spec.InitContainers[0].Image)
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/controller/install/scheduler_controller.go
+++ b/internal/controller/install/scheduler_controller.go
@@ -414,7 +414,7 @@ func newSchedulerMigrationJob(scheduler *installv1alpha1.Scheduler, serviceAccou
 					SecurityContext:               scheduler.Spec.PodSecurityContext,
 					InitContainers: []corev1.Container{{
 						Name:  "scheduler-migration-db-wait",
-						Image: "postgres:15.2-alpine",
+						Image: migrationDbWaitImageString(scheduler.Spec.MigrationDbWaitImage),
 						Command: []string{
 							"/bin/sh",
 							"-c",

--- a/internal/controller/install/scheduler_controller_test.go
+++ b/internal/controller/install/scheduler_controller_test.go
@@ -1352,6 +1352,26 @@ func Test_createSchedulerMigrationJob(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "The default image is used for the db-wait init container",
+			verifyJob: func(t *testing.T, job *batchv1.Job) {
+				assert.Equal(t, "postgres:15.2-alpine", job.Spec.Template.Spec.InitContainers[0].Image)
+			},
+			wantErr: false,
+		},
+		{
+			name: "MigrationDbWaitImage sets the image of the db-wait init container",
+			modifyInput: func(cr *v1alpha1.Scheduler) {
+				cr.Spec.MigrationDbWaitImage = &v1alpha1.Image{
+					Repository: "my-mirror.example.com/postgres",
+					Tag:        "15.2-alpine",
+				}
+			},
+			verifyJob: func(t *testing.T, job *batchv1.Job) {
+				assert.Equal(t, "my-mirror.example.com/postgres:15.2-alpine", job.Spec.Template.Spec.InitContainers[0].Image)
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
## What this PR does

The Lookout and Scheduler migration jobs run an init container that waits for Postgres and creates the database. The image of this init container was hardcoded to `postgres:15.2-alpine`, so clusters that pull only from an internal mirror could not run the migration jobs.

This PR adds an optional `migrationDbWaitImage` field to the Lookout and Scheduler CRDs:

```yaml
spec:
  migrationDbWaitImage:
    repository: my-internal-mirror.example.com/postgres
    tag: 15.2-alpine
```

When the field is not set, the operator keeps the current default of `postgres:15.2-alpine`, so existing installations do not change.

## Changes

- Add the `migrationDbWaitImage` field to `LookoutSpec` and `SchedulerSpec`. The field reuses the existing `Image` type, so it gets the same validation as the main image.
- Add the `migrationDbWaitImageString` helper that returns the configured image or the default.
- Use the helper in the Lookout and Scheduler migration job builders.
- Add unit tests for the default image and for a custom image.
- Regenerate the CRD manifests, the Helm chart CRDs, the deepcopy code, and the CRD reference docs.

Fixes #377